### PR TITLE
feat: useEffect 디펜던시 체크 추가 및 state를 getter 대신 값으로 받도록 개선[심규진]

### DIFF
--- a/src/components/AppHeader/RecentNewsRoll.ts
+++ b/src/components/AppHeader/RecentNewsRoll.ts
@@ -6,8 +6,8 @@ import { useState, useEffect } from "@/libs/createApp";
 import { getRecentNews } from "@/remotes/getRecentNews";
 
 export const RecentNewsRoll = ({ needDelay }: { needDelay: boolean }) => {
-  const [isHovering, setIsHovering] = useState(false);
-  const [from, setFrom] = useState(0);
+  const [isHovering, setIsHovering] = useState("news-roll", false);
+  const [from, setFrom] = useState("news-roll", 0);
 
   const { news, mediaId } = getRecentNews({
     from: from * 2 + (needDelay ? 1 : 0),
@@ -15,16 +15,14 @@ export const RecentNewsRoll = ({ needDelay }: { needDelay: boolean }) => {
   });
   const update = () => {
     if (isHovering) return;
-    setFrom((prev) => {
-      return prev + 1;
-    });
+    setFrom(from + 1);
   };
   useEffect(() => {
     const interval = setInterval(update, 5000);
     return () => {
       clearInterval(interval);
     };
-  }, []);
+  }, [from]);
   const media = getMediaById(mediaId);
 
   return Div({

--- a/src/components/AppHeader/RecentNewsRoll.ts
+++ b/src/components/AppHeader/RecentNewsRoll.ts
@@ -6,21 +6,23 @@ import { useState, useEffect } from "@/libs/createApp";
 import { getRecentNews } from "@/remotes/getRecentNews";
 
 export const RecentNewsRoll = ({ needDelay }: { needDelay: boolean }) => {
-  const [getIsHovering, setIsHovering] = useState(false);
-  const [getFrom, setFrom] = useState(0);
+  const [isHovering, setIsHovering] = useState(false);
+  const [from, setFrom] = useState(0);
+
   const { news, mediaId } = getRecentNews({
-    from: getFrom() * 2 + (needDelay ? 1 : 0),
+    from: from * 2 + (needDelay ? 1 : 0),
     limit: 2,
   });
   useEffect(() => {
     const interval = setInterval(() => {
-      if (getIsHovering()) return;
-      setFrom(getFrom() + 1);
+      console.log("interval", needDelay);
+      if (isHovering) return;
+      setFrom(from + 1);
     }, 5000);
     return () => {
       clearInterval(interval);
     };
-  });
+  }, []);
   const media = getMediaById(mediaId);
 
   return Div({

--- a/src/components/AppHeader/RecentNewsRoll.ts
+++ b/src/components/AppHeader/RecentNewsRoll.ts
@@ -13,12 +13,14 @@ export const RecentNewsRoll = ({ needDelay }: { needDelay: boolean }) => {
     from: from * 2 + (needDelay ? 1 : 0),
     limit: 2,
   });
+  const update = () => {
+    if (isHovering) return;
+    setFrom((prev) => {
+      return prev + 1;
+    });
+  };
   useEffect(() => {
-    const interval = setInterval(() => {
-      console.log("interval", needDelay);
-      if (isHovering) return;
-      setFrom(from + 1);
-    }, 5000);
+    const interval = setInterval(update, 5000);
     return () => {
       clearInterval(interval);
     };

--- a/src/components/AppHeader/RecentNewsRoll.ts
+++ b/src/components/AppHeader/RecentNewsRoll.ts
@@ -3,14 +3,13 @@ import { getMediaById } from "../../remotes/getMediaById";
 import typoStyles from "@/styles/typo.module.css";
 import styles from "./RecentNewsRoll.module.css";
 import { useState, useEffect } from "@/libs/createApp";
-import { getRecentNews } from "@/remotes/getRecentNewsList";
+import { getRecentNews } from "@/remotes/getRecentNews";
 
-export const RecentNewsRoll = ({ differ }: { differ: number }) => {
+export const RecentNewsRoll = ({ needDelay }: { needDelay: boolean }) => {
   const [getIsHovering, setIsHovering] = useState(false);
   const [getFrom, setFrom] = useState(0);
-
   const { news, mediaId } = getRecentNews({
-    from: getFrom() * 2 + differ,
+    from: getFrom() * 2 + (needDelay ? 1 : 0),
     limit: 2,
   });
   useEffect(() => {

--- a/src/components/AppHeader/TopSection.ts
+++ b/src/components/AppHeader/TopSection.ts
@@ -1,14 +1,24 @@
 import { Section } from "../../libs/Elements";
 import styles from "./TopSection.module.css";
 import { RecentNewsRoll } from "./RecentNewsRoll";
+import { useEffect, useState } from "@/libs/createApp";
 export const TopSection = () => {
+  const [showDelayed, setShowDelayed] = useState(false);
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setShowDelayed(true);
+    }, 1000);
+    return () => {
+      clearTimeout(timeout);
+    };
+  });
   return Section({
     className: `${styles.container}`,
     children: [
       RecentNewsRoll({
-        differ: 0,
+        needDelay: false,
       }),
-      RecentNewsRoll({ differ: 1 }),
+      showDelayed ? RecentNewsRoll({ needDelay: true }) : "",
     ],
   });
 };

--- a/src/components/AppHeader/TopSection.ts
+++ b/src/components/AppHeader/TopSection.ts
@@ -3,7 +3,7 @@ import styles from "./TopSection.module.css";
 import { RecentNewsRoll } from "./RecentNewsRoll";
 import { useEffect, useState } from "@/libs/createApp";
 export const TopSection = () => {
-  const [showDelayed, setShowDelayed] = useState(false);
+  const [showDelayed, setShowDelayed] = useState("top-section", false);
   useEffect(() => {
     const timeout = setTimeout(() => {
       setShowDelayed(true);

--- a/src/components/Medias/index.ts
+++ b/src/components/Medias/index.ts
@@ -24,7 +24,7 @@ const MediasContent = () => {
 export const Medias = () => {
   const [currentCategory, setCurrentCategory] = useState<
     "전체 언론사" | "내가 구독한 언론사"
-  >("전체 언론사");
+  >("Medias", "전체 언론사");
 
   return Section({
     children: [

--- a/src/components/Medias/index.ts
+++ b/src/components/Medias/index.ts
@@ -22,7 +22,7 @@ const MediasContent = () => {
   return "";
 };
 export const Medias = () => {
-  const [getCurrentCategory, setCurrentCategory] = useState<
+  const [currentCategory, setCurrentCategory] = useState<
     "전체 언론사" | "내가 구독한 언론사"
   >("전체 언론사");
 
@@ -37,7 +37,7 @@ export const Medias = () => {
             },
             style: {
               cursor: "pointer",
-              color: getCurrentCategory() === "전체 언론사" ? "blue" : "black",
+              color: currentCategory === "전체 언론사" ? "blue" : "black",
             },
           }),
           Span({
@@ -48,9 +48,7 @@ export const Medias = () => {
             style: {
               cursor: "pointer",
               color:
-                getCurrentCategory() === "내가 구독한 언론사"
-                  ? "blue"
-                  : "black",
+                currentCategory === "내가 구독한 언론사" ? "blue" : "black",
             },
           }),
         ],

--- a/src/libs/AppElement.ts
+++ b/src/libs/AppElement.ts
@@ -86,7 +86,17 @@ export const AppElement = ({
       elem.setAttribute(key, value);
     }
   };
-  Object.keys(props).forEach(parseProp);
+  const mount = () => {
+    Object.keys(props).forEach(parseProp);
+  };
+
+  const unmount = () => {
+    eventListeners.forEach((value, key) => {
+      elem.removeEventListener(key, value);
+    });
+  };
+  unmount();
+  mount();
   return {
     node: elem,
     eventListeners,

--- a/src/libs/createApp.ts
+++ b/src/libs/createApp.ts
@@ -142,13 +142,18 @@ const createApp = () => {
   };
   const useState = <RawT = unknown>(initalState: RawT) => {
     type T = RawT extends unknown ? typeof initalState : RawT;
+    type Updater = (updater: T | ((state: T) => T)) => void;
     const localStatesKey = statesKey;
     if (!states.has(localStatesKey)) {
       states.set(localStatesKey, initalState);
     }
     const state = states.get(localStatesKey) as T;
+    function update(updater: Updater) {
+      const newState =
+        typeof updater === "function"
+          ? (updater as (state: T) => T)(state)
+          : updater;
 
-    const update = (newState: T) => {
       if (state == newState) {
         return;
       }
@@ -160,9 +165,9 @@ const createApp = () => {
       }
       states.set(localStatesKey, newState);
       render();
-    };
+    }
     statesKey += 1;
-    return [state, update] as [T, (newState: T) => void];
+    return [state, update] as [T, Updater];
   };
 
   return {

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -10,3 +10,16 @@ export const debounceAnimationCallback = (callback: () => void) => {
     });
   };
 };
+
+export const toStringAnything = (value: any) => {
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return value.toString();
+};

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -11,6 +11,19 @@ export const debounceAnimationCallback = (callback: () => void) => {
   };
 };
 
+export const debounce = (callback: () => void, delay: number) => {
+  let timeout: number | null = null;
+  return () => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(() => {
+      callback();
+      timeout = null;
+    }, delay);
+  };
+};
+
 export const toStringAnything = (value: any) => {
   if (value === undefined) {
     return "undefined";

--- a/src/remotes/getRecentNews.ts
+++ b/src/remotes/getRecentNews.ts
@@ -1,5 +1,6 @@
 import { RecentNews } from "../models/News";
 
+// TODO change file name
 interface GetRecentNewsProps {
   from: number;
   limit?: number;


### PR DESCRIPTION
## changes
- useEffect 디펜던시 체크 추가 
- state를 getter 대신 값으로 받도록 개선
- 기타 마이너한 변경 사항
- state update를 callback으로 가능하도록 개선
- 렌더 중 state 갱신에 대한 대응

## todo
- 라이브러리 부분에 한해서 테스트 코드를 도입해볼까 고민 중
- 매번 변경할 때 마다 동작을 테스트하기 어렵다.
- 다른 프레임웤 분석

## known bugs
### 타이머 states 갱신 버그
- `setInterval`에서 비동기로 상태를 갱신하고 있기에 주기가 잘못 겹친다면 `states` 맵의 각 컴포넌트 인덱스가 동적으로 변함.
- 이를 해결하기 위해서는 key를 유니크한 값으로 제공해줘야 함.
- 혹은 렌더 방식에 대한 획기적인 대격변이 필요.
#### 시도 1
- 클래스형으로 바꿔서 `mount`와 `render` 분기 -> 이는 결국 함수형 컴포넌트 + 훅이라는 구조에서 벗어나지 않으면 불가능

#### 시도 2
- key를 잘 부여해주기(부모 이름 + 함수 이름) ->  이것 역시 함수형 컴포넌트 + 훅이라는 구조에서 벗어나지 않으면 불가능

#### 정론
- 함수형 컴포넌트를 실행시키는 것이 아닌 props와 함수 실행만 렌더로 전달해줘야 한다. 마치 JSX 처럼. 
- 그래서 오브젝트 구조로 UI를 나타낼 수는 없을까 고민해봄
```tsx
{
  component: 'div' or App,
  props: {}
}
```
#### 대안 1
- 렌더 중에는 상태 갱신을 막고 deque에 담아둘까? 
- 렌더 이후 deque의 상태 변화 함수를 모두 실행 시킨 이후 다시 렌더에 돌입한다면?
--> 렌더 시간이 짧아서 영향 없음

#### 대안 2 
- 유저가 훅 사용 시 고유한 key 값을 제공함(시도 2번의 약간 변형 버전)
--> 이 방법으로 해결