### PR TITLE
[한기종] Feat: 상태관리 코어 기능 추가, 전체 리스트 뷰, 그리드 뷰 페이지네이션 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,8 +39,10 @@
 					</svg>
 				</div>
 			</nav>
-			<section id="newsSection">
-			</section>
+			<div class="mainBoxWrapper">
+				<section id="newsSection">
+				</section>
+			</div>
 			<div id="leftMoveButton" class="moveIcon left">
 				<svg width="24" height="40">
 					<path d="M24 0 L 0 20 L 24 40" fill="none" stroke="inherit" strokeWidth="1" />

--- a/index.html
+++ b/index.html
@@ -42,6 +42,8 @@
 			<div class="mainBoxWrapper">
 				<section id="newsSection">
 				</section>
+				<section id="modalSection">
+				</section>
 			</div>
 			<div id="leftMoveButton" class="moveIcon left">
 				<svg width="24" height="40">

--- a/js/diffing.js
+++ b/js/diffing.js
@@ -47,6 +47,7 @@ function makeRelativeNodePositionMap(children)
 function replaceTo(oldDom, newDom)
 {
 	const parent = oldDom.parentNode;
+	console.log("replaced", parent, oldDom, newDom);
 	parent.insertBefore(newDom, oldDom);
 	parent.removeChild(oldDom);
 }
@@ -87,7 +88,6 @@ function applyDiffChildren(targetDom, childList)
 	for(let [uniqueKey, child] of newNodeKeyMap)
 	{
 		if(!oldNodeKeyMap.has(uniqueKey)) targetDom.append(child);
-		else _applyDiff(oldNodeKeyMap.get(uniqueKey), child);
 	}
 
 	// 자식의 상대적 위치를 저장하는 별도의 맵을 만듭니다.
@@ -100,6 +100,13 @@ function applyDiffChildren(targetDom, childList)
 		if(oldNodeNextMap.get(uniqueKey) !== newNodeNextMap.get(uniqueKey) ){
 			const nextNode = oldNodeKeyMap.get(newNodeNextMap.get(uniqueKey)) ?? null;
 			targetDom.insertBefore(child, nextNode);
+		}
+	}
+
+	for(let [uniqueKey, child] of newNodeKeyMap)
+	{
+		if(oldNodeKeyMap.has(uniqueKey)) {
+			_applyDiff(oldNodeKeyMap.get(uniqueKey), child);
 		}
 	}
 }

--- a/js/diffing.js
+++ b/js/diffing.js
@@ -47,7 +47,6 @@ function makeRelativeNodePositionMap(children)
 function replaceTo(oldDom, newDom)
 {
 	const parent = oldDom.parentNode;
-	console.log("replaced", parent, oldDom, newDom);
 	parent.insertBefore(newDom, oldDom);
 	parent.removeChild(oldDom);
 }

--- a/js/diffing.js
+++ b/js/diffing.js
@@ -133,14 +133,14 @@ function _applyDiff(oldDom, newDom)
 
 function applyDiff(root, target)
 {
-	if(root.children.length === 0) {
+	if(root.childNodes.length === 0) {
 		root.appendChild(target);
 		return;
 	}
 	if(target instanceof DocumentFragment) {
 		applyDiffChildren(root, target.childNodes);
 	}
-	else if(root.children.length > 1) {
+	else if(root.childNodes.length > 1) {
 		applyDiffChildren(root, [target]);
 	}
 	else _applyDiff(root.firstChild, target);

--- a/js/diffing.js
+++ b/js/diffing.js
@@ -129,11 +129,12 @@ function _applyDiff(oldDom, newDom)
 		return;
 	}
 	
-	// 그 외의 경우(노드타입이 같고 태그명도 같다면, 속성을 변경하고 children을 변경한다.)
-	if(newDom.dataset.forceReplace) {
+	// forceReplace 속성이 true이거나, forceReplace 속성이 이전 것과 다르다면, 완전히 변경시킨다.
+	if(newDom.dataset.forceReplace === "true" || (newDom.dataset.forceReplace !== undefined && newDom.dataset.forceReplace !== oldDom.dataset.forceReplace)) {
 		replaceTo(oldDom, newDom);
 		return;
 	}
+	// 그 외의 경우(노드타입이 같고 태그명도 같다면, 속성을 변경하고 children을 변경한다.)
 	else applyDiffAttributes(oldDom, newDom);
 	applyDiffChildren(oldDom, newDom.childNodes);
 }

--- a/js/domParser.js
+++ b/js/domParser.js
@@ -31,6 +31,7 @@ function makePlainHTML(plains, elems)
 		else result += `${elems[i]}`.replace("<", "&lt;").replace(">", "&gt;");
 		result += plains[i+1];
 	}
+	result.replace(/\>\s+\</, "><");
 	return result;
 }
 
@@ -52,6 +53,29 @@ function convertArrayToFragment(array)
 	return frag;
 }
 
+function removeEmptyTextNodes(element) {
+  // Check if the element has child nodes
+  if (element.hasChildNodes()) {
+    for (let childNode of element.childNodes) {
+      // Check if the child node is a Text node
+      if (childNode.nodeType === Node.TEXT_NODE) {
+        // Check if the text content is only whitespace
+        if (childNode.textContent.trim() === '') {
+          // Remove the empty Text node
+          element.removeChild(childNode);
+        } else {
+          // Recursively check child nodes of the Text node
+          removeEmptyTextNodes(childNode);
+        }
+      } else {
+        // Recursively check child nodes of the current element
+        removeEmptyTextNodes(childNode);
+      }
+    }
+  }
+  return element;
+}
+
 function domMaker(plains, ...elems)
 {
 	const plainHTML = makePlainHTML(plains, elems);
@@ -66,7 +90,7 @@ function domMaker(plains, ...elems)
 		holders[i].remove();
 	}
 
-	return dom;
+	return removeEmptyTextNodes(dom);
 }
 
 export default domMaker;

--- a/js/index.js
+++ b/js/index.js
@@ -8,6 +8,7 @@ import mountPageMoverSelector from "./views/mountPageMoverSelector.js";
 import mountView from "./views/mainView.js";
 
 const {list: fullList, metadata} = processListPagination(rawData);
+
 const [state, reducer] = generateReducer(fullList);
 
 mountLeftSelector(state.subFilter, reducer.setFullView, reducer.setSubscribedView);

--- a/js/index.js
+++ b/js/index.js
@@ -13,9 +13,7 @@ const [state, reducer] = generateReducer(fullList);
 mountLeftSelector(state.subFilter, reducer.setFullView, reducer.setSubscribedView);
 mountRightSelector(state.viewType, reducer.setListView, reducer.setGridView);
 mountPageMoverSelector(state.cursor, reducer);
-mountView(state, reducer, metadata);
-
-console.log(fullList);
+mountView(state, reducer, fullList, metadata);
 
 state.subFilter.addSideEffect( (e)=>console.log(`chnge sub filter : ${e}`) );
 state.viewType.addSideEffect( (e)=>console.log(`chnge view type : ${e}`) );

--- a/js/index.js
+++ b/js/index.js
@@ -19,4 +19,4 @@ console.log(fullList);
 
 state.subFilter.addSideEffect( (e)=>console.log(`chnge sub filter : ${e}`) );
 state.viewType.addSideEffect( (e)=>console.log(`chnge view type : ${e}`) );
-state.cursor.addSideEffect( (e)=>console.log(`chnge cursor state : ${e}`) );
+state.cursor.addSideEffect( (e)=>console.log(e) );

--- a/js/index.js
+++ b/js/index.js
@@ -17,4 +17,4 @@ mountView(state, reducer, fullList, metadata);
 
 state.subFilter.addSideEffect( (e)=>console.log(`chnge sub filter : ${e}`) );
 state.viewType.addSideEffect( (e)=>console.log(`chnge view type : ${e}`) );
-state.cursor.addSideEffect( (e)=>console.log(e) );
+state.subList.addSideEffect( (e)=>console.log(`change subList : ${e}`) );

--- a/js/index.js
+++ b/js/index.js
@@ -15,6 +15,8 @@ mountRightSelector(state.viewType, reducer.setListView, reducer.setGridView);
 mountPageMoverSelector(state.cursor, reducer);
 mountView(state, reducer, metadata);
 
+console.log(fullList);
+
 state.subFilter.addSideEffect( (e)=>console.log(`chnge sub filter : ${e}`) );
 state.viewType.addSideEffect( (e)=>console.log(`chnge view type : ${e}`) );
 state.cursor.addSideEffect( (e)=>console.log(`chnge cursor state : ${e}`) );

--- a/js/index.js
+++ b/js/index.js
@@ -12,7 +12,7 @@ const [state, reducer] = generateReducer(fullList);
 
 mountLeftSelector(state.subFilter, reducer.setFullView, reducer.setSubscribedView);
 mountRightSelector(state.viewType, reducer.setListView, reducer.setGridView);
-mountPageMoverSelector(state.cursor, reducer);
+mountPageMoverSelector(state, reducer);
 mountView(state, reducer, fullList, metadata);
 
 state.subFilter.addSideEffect( (e)=>console.log(`chnge sub filter : ${e}`) );

--- a/js/index.js
+++ b/js/index.js
@@ -1,3 +1,20 @@
+import rawData from "./rawData.js";
+import processListPagination from "./processData/processListPagination.js";
+import generateReducer from "./states/generateReducer.js";
+import mountLeftSelector from "./views/mountLeftSelector.js";
+import mountRightSelector from "./views/mountRightSelector.js";
+import mountPageMoverSelector from "./views/mountPageMoverSelector.js";
+
 import mountView from "./views/mainView.js";
 
-mountView(document.getElementById("newsSection"));
+const {list: fullList, metadata} = processListPagination(rawData);
+const [state, reducer] = generateReducer(fullList);
+
+mountLeftSelector(state.subFilter, reducer.setFullView, reducer.setSubscribedView);
+mountRightSelector(state.viewType, reducer.setListView, reducer.setGridView);
+mountPageMoverSelector(state.cursor, reducer);
+mountView(state, reducer, metadata);
+
+state.subFilter.addSideEffect( (e)=>console.log(`chnge sub filter : ${e}`) );
+state.viewType.addSideEffect( (e)=>console.log(`chnge view type : ${e}`) );
+state.cursor.addSideEffect( (e)=>console.log(`chnge cursor state : ${e}`) );

--- a/js/processData/processListPagination.js
+++ b/js/processData/processListPagination.js
@@ -17,9 +17,10 @@ function generatePaginationGroup(rawData)
 
 function generatePaginationMetadata(groupedPressList)
 {
+	console.log(groupedPressList);
 	const categoryName = ["종합/경제", "방송/통신", "IT", "영자지", "스포츠/연예", "매거진/전문지", "지역"];
 
-	const metadata = new Array(categories.length);
+	const metadata = [];
 	for(let i=0; i<metadata.length; i++)
 	{
 		let allPages = groupedPressList[i].length;

--- a/js/processData/processListPagination.js
+++ b/js/processData/processListPagination.js
@@ -17,17 +17,19 @@ function generatePaginationGroup(rawData)
 
 function generatePaginationMetadata(groupedPressList)
 {
-	console.log(groupedPressList);
 	const categoryName = ["종합/경제", "방송/통신", "IT", "영자지", "스포츠/연예", "매거진/전문지", "지역"];
 
 	const metadata = [];
-	for(let i=0; i<metadata.length; i++)
+	let sum = 0;
+	for(let i=0; i<categoryName.length; i++)
 	{
-		let allPages = groupedPressList[i].length;
-		let offset = i === 0 ? 0 : groupedPressList[i-1].length;
-		metadata.push( { allPages, offset, name: categoryName[i] } );
-	}
+		let pages = groupedPressList[i].length;
+		if(pages === 0) continue;
 
+		let offset = sum;
+		sum += groupedPressList[i].length;
+		metadata.push( { pages, offset, name: categoryName[i], destination: groupedPressList[i][0]?.key ?? null } );
+	}
 	return metadata;
 }
 

--- a/js/processData/processPaginationData.js
+++ b/js/processData/processPaginationData.js
@@ -1,0 +1,44 @@
+function generatePaginationGroup(rawData)
+{
+	const categories = ["general", "broadcast", "it", "youngjaji", "sport", "magagine", "local"];
+	
+	const groupedPressList = Array.from(categories, ()=>[]);
+	const copiedRawData = Object.entries(rawData).map( ([key, value])=>({key, name: value.name, category: value.category}) );
+
+	for(let eachData of copiedRawData)
+	{
+		let groupIndex = categories.indexOf(eachData.category);
+		groupedPressList[groupIndex].push(eachData);
+	}
+	groupedPressList.forEach( (eachGroup)=>eachGroup.sort( (a,b)=>a.name - b.name ) );
+
+	return groupedPressList;
+}
+
+function generatePaginationMetadata(groupedPressList)
+{
+	const categoryName = ["종합/경제", "방송/통신", "IT", "영자지", "스포츠/연예", "매거진/전문지", "지역"];
+
+	const metadata = new Array(categories.length);
+	for(let i=0; i<metadata.length; i++)
+	{
+		let allPages = groupedPressList[i].length;
+		let offset = i === 0 ? 0 : groupedPressList[i-1].length;
+		metadata.push( { allPages, offset, name: categoryName[i] } );
+	}
+
+	return metadata;
+}
+
+
+function processListPagination(rawData)
+{
+	const group = generatePaginationGroup(rawData);
+	const metadata = generatePaginationMetadata(group);
+	return {
+		list: group.flat(Infinity).map( ({key})=>key ),
+		metadata
+	};
+}
+
+export default processListPagination;

--- a/js/states/cursorAdaptor.js
+++ b/js/states/cursorAdaptor.js
@@ -50,7 +50,7 @@ CursorAdaptor.prototype.getLast = function()
 
 CursorAdaptor.prototype.findOffset = function(offset)
 {
-	return this.cursor.findOffset();
+	return this.cursor.findOffset(offset);
 }
 
 CursorAdaptor.prototype.getDataList = function(num)

--- a/js/states/cursorAdaptor.js
+++ b/js/states/cursorAdaptor.js
@@ -58,9 +58,9 @@ CursorAdaptor.prototype.getDataList = function(num)
 	return this.cursor.getDataList(num);
 }
 
-CursorAdaptor.prototype.addSideEffect = function(func)
+CursorAdaptor.prototype.addSideEffect = function(func, key)
 {
-	this.state.addSideEffect(func);
+	this.state.addSideEffect(func, key);
 }
 
 CursorAdaptor.prototype.removeSideEffect = function(func)

--- a/js/states/cursorAdaptor.js
+++ b/js/states/cursorAdaptor.js
@@ -1,0 +1,71 @@
+import State from "./state.js";
+import PaginationCursor from "./paginationCursor.js";
+
+// 어댑터 패턴
+function CursorAdaptor(linkedList, sideEffect=null)
+{
+	this.cursor = new PaginationCursor(linkedList);
+	this.state = new State(this.cursor.current, sideEffect);
+}
+
+CursorAdaptor.prototype.moveBefore = function(delta=1)
+{
+	this.cursor.moveBefore(delta);
+	this.state.change(this.cursor.current);
+}
+
+CursorAdaptor.prototype.moveNext = function(delta=1)
+{
+	this.cursor.moveNext(delta);
+	this.state.change(this.cursor.current);
+}
+
+CursorAdaptor.prototype.moveTo = function(id)
+{
+	this.cursor.moveTo(id);
+	this.state.change(this.cursor.current);
+}
+
+CursorAdaptor.prototype.moveFirst = function()
+{
+	this.cursor.moveFirst();
+	this.state.change(this.cursor.current);
+}
+
+CursorAdaptor.prototype.changeLinkedList = function(linkedList)
+{
+	this.cursor.changeLinkedList(linkedList);
+	this.state.change(this.cursor.current);
+}
+
+CursorAdaptor.prototype.getFirst = function()
+{
+	return this.cursor.getFirstKey();
+}
+
+CursorAdaptor.prototype.getLast = function()
+{
+	return this.cursor.getLastKey();
+}
+
+CursorAdaptor.prototype.findOffset = function(offset)
+{
+	return this.cursor.findOffset();
+}
+
+CursorAdaptor.prototype.getDataList = function(num)
+{
+	return this.cursor.getDataList(num);
+}
+
+CursorAdaptor.prototype.addSideEffect = function(func)
+{
+	this.state.addSideEffect(func);
+}
+
+CursorAdaptor.prototype.removeSideEffect = function(func)
+{
+	this.state.removeSideEffect(func);
+}
+
+export default CursorAdaptor;

--- a/js/states/cursorAdaptor.js
+++ b/js/states/cursorAdaptor.js
@@ -56,6 +56,11 @@ CursorAdaptor.prototype.findOffset = function(offset)
 	return this.cursor.findOffset(offset);
 }
 
+CursorAdaptor.prototype.isOutOfList = function()
+{
+	return this.cursor.isOutOfList();
+}
+
 CursorAdaptor.prototype.getDataList = function(num)
 {
 	return this.cursor.getDataList(num);

--- a/js/states/cursorAdaptor.js
+++ b/js/states/cursorAdaptor.js
@@ -6,6 +6,9 @@ function CursorAdaptor(linkedList, sideEffect=null)
 {
 	this.cursor = new PaginationCursor(linkedList);
 	this.state = new State(this.cursor.current, sideEffect);
+	Object.defineProperty(this, "value", {
+		get: function(){return this.state.value;}
+	});
 }
 
 CursorAdaptor.prototype.moveBefore = function(delta=1)

--- a/js/states/derivedState.js
+++ b/js/states/derivedState.js
@@ -3,9 +3,9 @@ import stateBatchUpdater from "./stateBatchUpdater.js";
 function DerivedState(func, dependency)
 {
 	this.__sideEffects = new Map();
-	this.value = func(...dependency);
+	this.value = func(dependency.map( state=>state.value ), null);
 	const calculateValue = (des)=>{
-		const newValue = func(...dependency.map( state=>state.value ));
+		const newValue = func(dependency.map( state=>state.value ), this.value);
 		if(this.value !== newValue) stateBatchUpdater.callUpdate(this, newValue);
 	}
 	dependency.forEach( (state, i)=>state.addSideEffect(calculateValue, i) );

--- a/js/states/derivedState.js
+++ b/js/states/derivedState.js
@@ -1,0 +1,36 @@
+import stateBatchUpdater from "./stateBatchUpdater.js";
+
+function DerivedState(func, dependency)
+{
+	this.__sideEffects = new Map();
+	this.value = func(...dependency);
+	const calculateValue = (des)=>{
+		const newValue = func(...dependency.map( state=>state.value ));
+		if(this.value !== newValue) stateBatchUpdater.callUpdate(this, newValue);
+	}
+	dependency.forEach( (state, i)=>state.addSideEffect(calculateValue, i) );
+
+	this.__applyChange = (newValue)=>{
+		if(this.value === newValue) return;
+		const oldValue = this.value;
+		this.value = newValue;
+		stateBatchUpdater.__appendSideEffects(this.__sideEffects, newValue, oldValue);
+	}
+}
+
+DerivedState.prototype.addSideEffect = function(func, key="default")
+{
+	this.__sideEffects.set(func, key);
+}
+
+DerivedState.prototype.removeSideEffect = function(func)
+{
+	this.__sideEffects.delete(func);
+}
+
+DerivedState.prototype.valueOf = function()
+{
+	return this.value;
+}
+
+export default DerivedState;

--- a/js/states/generateReducer.js
+++ b/js/states/generateReducer.js
@@ -15,9 +15,11 @@ function generateReducer(fullList)
 	const subscribedListState = new LinkedListAdaptor(subscribedLinkedList);
 	const cursorState = new CursorAdaptor(fullLinkedList);
 
+	const GRID_ITEMS_PER_PAGE = 24;
+
 	function getDelta()
 	{
-		return viewTypeState.value === "list" ? 1 : 24;
+		return viewTypeState.value === "list" ? 1 : GRID_ITEMS_PER_PAGE;
 	}
 
 	// derived state

--- a/js/states/generateReducer.js
+++ b/js/states/generateReducer.js
@@ -1,4 +1,5 @@
 import State from "./state.js";
+import DerivedState from "./derivedState.js";
 import LinkedList from "./linkedList.js";
 import LinkedListAdaptor from "./linkedListAdaptor.js";
 import CursorAdaptor from "./cursorAdaptor.js";
@@ -8,6 +9,7 @@ function generateReducer(fullList)
 	const fullLinkedList = new LinkedList(fullList);
 	const subscribedLinkedList = new LinkedList();
 
+	// state
 	const subscribeFilterState = new State(false);
 	const viewTypeState = new State("list");
 	const subscribedListState = new LinkedListAdaptor(subscribedLinkedList);
@@ -18,13 +20,23 @@ function generateReducer(fullList)
 		return viewTypeState.value === "list" ? 1 : 24;
 	}
 
+	// derived state
+	const isFirstPage = new DerivedState( ()=>{
+		return cursorState.findOffset(-getDelta()) === null;
+	}, [cursorState, viewTypeState, subscribeFilterState, subscribedListState] );
+	const isLastPage = new DerivedState( ()=>{
+		return cursorState.findOffset(getDelta()) === null;
+	}, [cursorState, viewTypeState, subscribeFilterState, subscribedListState] );
+
 	return [
 		// state
 		{
 			subFilter : subscribeFilterState,
 			viewType : viewTypeState,
 			subList: subscribedListState,
-			cursor: cursorState
+			cursor: cursorState,
+			isFirstPage,
+			isLastPage
 		},
 		// reducer
 		{
@@ -74,14 +86,6 @@ function generateReducer(fullList)
 				subscribedListState.delete(value);
 			},
 			// derived state
-			isFirstPage()
-			{
-				return cursorState.findOffset(-getDelta()) === null;
-			},
-			isLastPage()
-			{
-				return cursorState.findOffset(getDelta()) === null;
-			},
 			beforeCursor()
 			{
 				return cursorState.findOffset(-getDelta());

--- a/js/states/generateReducer.js
+++ b/js/states/generateReducer.js
@@ -1,0 +1,97 @@
+import State from "./state.js";
+import LinkedList from "./linkedList.js";
+import LinkedListAdaptor from "./linkedListAdaptor.js";
+import CursorAdaptor from "./cursorAdaptor.js";
+
+function generateReducer(fullList)
+{
+	const fullLinkedList = new LinkedList(fullList);
+	const subscribedLinkedList = new LinkedList();
+
+	const subscribeFilterState = new State(false);
+	const viewTypeState = new State("list");
+	const subscribedListState = new LinkedListAdaptor(subscribedLinkedList);
+	const cursorState = new CursorAdaptor(fullLinkedList);
+
+	function getDelta()
+	{
+		return viewTypeState.value === "list" ? 1 : 24;
+	}
+
+	return [
+		// state
+		{
+			subFilter : subscribeFilterState,
+			viewType : viewTypeState,
+			subList: subscribedListState,
+			cursor: cursorState
+		},
+		// reducer
+		{
+			// setter
+			moveLeft()
+			{
+				cursorState.moveBefore(getDelta());
+			},
+			moveRight()
+			{
+				cursorState.moveNext(getDelta());
+			},
+			moveTo(to)
+			{
+				cursorState.moveTo(to);
+			},
+			setFullView()
+			{
+				subscribeFilterState.change(false);
+				viewTypeState.change("grid");
+				cursorState.changeLinkedList(fullLinkedList);
+				cursorState.moveFirst();
+			},
+			setSubscribedView()
+			{
+				subscribeFilterState.change(true);
+				viewTypeState.change("list");
+				cursorState.changeLinkedList(subscribedLinkedList);
+				cursorState.moveFirst();
+			},
+			setGridView()
+			{
+				viewTypeState.change("grid");
+				cursorState.moveFirst();
+			},
+			setListView()
+			{
+				viewTypeState.change("list");
+				cursorState.moveFirst();
+			},
+			addToSubscription(value)
+			{
+				subscribedListState.add(value);
+			},
+			removeFromSubscription(value)
+			{
+				subscribedListState.delete(value);
+			},
+			// derived state
+			isFirstPage()
+			{
+				return cursorState.findOffset(-getDelta()) === cursorState.getFirst();
+			},
+			isLastPage()
+			{
+				return cursorState.findOffset(getDelta()) === cursorState.getLast();
+			},
+			beforeCursor()
+			{
+				return cursorState.findOffset(-getDelta());
+			},
+			afterCursor()
+			{
+				return cursorState.findOffset(getDelta());
+			},
+		}
+	];
+}
+
+export default generateReducer;

--- a/js/states/generateReducer.js
+++ b/js/states/generateReducer.js
@@ -76,11 +76,11 @@ function generateReducer(fullList)
 			// derived state
 			isFirstPage()
 			{
-				return cursorState.findOffset(-getDelta()) === cursorState.getFirst();
+				return cursorState.findOffset(-getDelta()) === null;
 			},
 			isLastPage()
 			{
-				return cursorState.findOffset(getDelta()) === cursorState.getLast();
+				return cursorState.findOffset(getDelta()) === null;
 			},
 			beforeCursor()
 			{

--- a/js/states/generateReducer.js
+++ b/js/states/generateReducer.js
@@ -24,7 +24,12 @@ function generateReducer(fullList)
 	const isFirstPage = new DerivedState( ()=>{
 		return cursorState.findOffset(-getDelta()) === null;
 	}, [cursorState, viewTypeState, subscribeFilterState, subscribedListState] );
-	const isLastPage = new DerivedState( ()=>{
+	const isLastPage = new DerivedState( ([cursor, viewType, subscFilter, subscList])=>{
+		// 리스트에서 구독이 취소되었을 때, 다음 버튼이 존재했다면 그것을 유지시키기 위함.
+		// 그리드에서는 동적으로 내용이 바뀌므로 필요없음
+		if(subscFilter && viewType === "list" && cursorState.isOutOfList()) {
+			return cursorState.findOffset(0) === null;
+		}
 		return cursorState.findOffset(getDelta()) === null;
 	}, [cursorState, viewTypeState, subscribeFilterState, subscribedListState] );
 

--- a/js/states/linkedList.js
+++ b/js/states/linkedList.js
@@ -64,6 +64,17 @@ class LinkedList
 	findKeyAtOffset(basis, offset)
 	{
 		if(!this.has(basis)) return null;
+		const result = this.findKeyAtOffsetNoOverflow(basis, offset);
+		if(result === null)
+		{
+			if(offset < 0) return this.first;
+			else return this.last;
+		}
+		return result;
+	}
+	findKeyAtOffsetNoOverflow(basis, offset)
+	{
+		if(!this.has(basis)) return null;
 
 		if(offset === 0) return basis;
 		if(offset < 0)
@@ -72,7 +83,7 @@ class LinkedList
 			for(let i=0; i<-offset; i++)
 			{
 				let before = this.get(cursor).prev;
-				if(before === null) break;
+				if(before === null) return null;
 				cursor = before;
 			}
 			return cursor;
@@ -83,7 +94,7 @@ class LinkedList
 			for(let i=0; i<offset; i++)
 			{
 				let after = this.get(cursor).next;
-				if(after === null) break;
+				if(after === null) return null;
 				cursor = after;
 			}
 			return cursor;

--- a/js/states/linkedList.js
+++ b/js/states/linkedList.js
@@ -61,6 +61,34 @@ class LinkedList
 
 		this.#map.delete(value);
 	}
+	findKeyAtOffset(basis, offset)
+	{
+		if(!this.has(basis)) return null;
+
+		if(offset === 0) return basis;
+		if(offset < 0)
+		{
+			let cursor = basis;
+			for(let i=0; i<-offset; i++)
+			{
+				let before = this.get(cursor).prev;
+				if(before === null) break;
+				cursor = before;
+			}
+			return cursor;
+		}
+		else
+		{
+			let cursor = basis;
+			for(let i=0; i<offset; i++)
+			{
+				let after = this.get(cursor).next;
+				if(after === null) break;
+				cursor = after;
+			}
+			return cursor;
+		}
+	}
 	*[Symbol.iterator]()
 	{
 		let cursor = this.first;

--- a/js/states/linkedList.js
+++ b/js/states/linkedList.js
@@ -1,0 +1,75 @@
+class LinkedList
+{
+	#map = null;
+	#first = null;
+	#last = null;
+	constructor(array=[])
+	{
+		this.#map = new Map(array.map( (value,i)=>{
+			let prev = array[i-1] ?? null;
+			let next = array[i+1] ?? null;
+			return [value, {prev, next}];
+		} ));
+		this.#first = array[0] ?? null;
+		this.#last = array[array.length-1] ?? null;
+	}
+	get first()
+	{
+		return this.#first;
+	}
+	get last()
+	{
+		return this.#last;
+	}
+	get array()
+	{
+		return [...this];
+	}
+	get(value)
+	{
+		return this.#map.get(value) ?? null;
+	}
+	has(value)
+	{
+		return this.#map.has(value);
+	}
+	add(value, prev = this.#last)
+	{
+		if(this.has(value)) this.delete(value);
+
+		let prevNode = this.has(prev) ? prev : null;
+		let nextNode = this.has(prev) ? this.get(prev).next : this.#first;
+
+		if(prevNode === null) this.#first = value;
+		else this.#map.set(prevNode, {prev: this.get(prevNode).prev, next: value});
+
+		this.#map.set(value, {prev:prevNode, next: nextNode});
+
+		if(nextNode === null) this.#last = value;
+		else this.#map.set(nextNode, {prev:value, next: this.get(nextNode).next});
+	}
+	delete(value)
+	{
+		if(!this.has(value)) return;
+		const {prev, next} = this.get(value);
+
+		if(prev === null) this.#first = next;
+		else this.#map.set(prev, {prev: this.get(prev).prev, next});
+
+		if(next === null) this.#last = prev;
+		else this.#map.set(next, {prev, next: this.get(next).next});
+
+		this.#map.delete(value);
+	}
+	*[Symbol.iterator]()
+	{
+		let cursor = this.first;
+		while(this.has(cursor))
+		{
+			yield cursor;
+			cursor = this.get(cursor).next;
+		}
+	}
+}
+
+export default LinkedList;

--- a/js/states/linkedListAdaptor.js
+++ b/js/states/linkedListAdaptor.js
@@ -22,6 +22,11 @@ LinkedListAdaptor.prototype.delete = function(value)
 	this.state.change(this.linkedList.array);
 }
 
+LinkedListAdaptor.prototype.has = function(value)
+{
+	return this.linkedList.has(value);
+}
+
 LinkedListAdaptor.prototype.change = function(newLinkedList)
 {
 	this.linkedList = newLinkedList;

--- a/js/states/linkedListAdaptor.js
+++ b/js/states/linkedListAdaptor.js
@@ -22,6 +22,11 @@ LinkedListAdaptor.prototype.delete = function(value)
 	this.state.change(this.linkedList.array);
 }
 
+LinkedListAdaptor.prototype.getPrev = function(value)
+{
+	return this.linkedList.get(value)?.prev;
+}
+
 LinkedListAdaptor.prototype.has = function(value)
 {
 	return this.linkedList.has(value);

--- a/js/states/linkedListAdaptor.js
+++ b/js/states/linkedListAdaptor.js
@@ -25,9 +25,9 @@ LinkedListAdaptor.prototype.change = function(newLinkedList)
 	this.state.change(this.linkedList.array);
 }
 
-LinkedListAdaptor.prototype.addSideEffect = function(func)
+LinkedListAdaptor.prototype.addSideEffect = function(func, key)
 {
-	this.state.addSideEffect(func);
+	this.state.addSideEffect(func, key);
 }
 
 LinkedListAdaptor.prototype.removeSideEffect = function(func)

--- a/js/states/linkedListAdaptor.js
+++ b/js/states/linkedListAdaptor.js
@@ -5,6 +5,9 @@ function LinkedListAdaptor(linkedList, sideEffect=null)
 {
 	this.linkedList = linkedList;
 	this.state = new State(linkedList.array, sideEffect);
+	Object.defineProperty(this, "value", {
+		get: function(){return this.state.value;}
+	});
 }
 
 LinkedListAdaptor.prototype.add = function(value, prev)

--- a/js/states/linkedListAdaptor.js
+++ b/js/states/linkedListAdaptor.js
@@ -1,0 +1,38 @@
+import State from "./state.js";
+
+// 어댑터 패턴
+function LinkedListAdaptor(linkedList, sideEffect=null)
+{
+	this.linkedList = linkedList;
+	this.state = new State(linkedList.array, sideEffect);
+}
+
+LinkedListAdaptor.prototype.add = function(value, prev)
+{
+	this.linkedList.add(value, prev);
+	this.state.change(this.linkedList.array);
+}
+
+LinkedListAdaptor.prototype.delete = function(value)
+{
+	this.linkedList.delete(value);
+	this.state.change(this.linkedList.array);
+}
+
+LinkedListAdaptor.prototype.change = function(newLinkedList)
+{
+	this.linkedList = newLinkedList;
+	this.state.change(this.linkedList.array);
+}
+
+LinkedListAdaptor.prototype.addSideEffect = function(func)
+{
+	this.state.addSideEffect(func);
+}
+
+LinkedListAdaptor.prototype.removeSideEffect = function(func)
+{
+	this.state.removeSideEffect(func);
+}
+
+export default LinkedListAdaptor;

--- a/js/states/paginationCursor.js
+++ b/js/states/paginationCursor.js
@@ -3,8 +3,18 @@ class PaginationCursor
 	constructor(linkedList = null)
 	{
 		this.attachedLinkedList = null;
-		this.current = null;
+		this._current = null;
+		this.neighbor = {prev: null, next: null};
 		if(linkedList !== null) this.changeLinkedList(linkedList);
+	}
+	get current()
+	{
+		return this._current;
+	}
+	set current(value)
+	{
+		this._current = value;
+		this.neighbor = this.attachedLinkedList.get(value) ?? {prev: null, next: null};
 	}
 	changeLinkedList(linkedList)
 	{
@@ -17,13 +27,17 @@ class PaginationCursor
 	moveBefore(delta = 1)
 	{
 		if(this.attachedLinkedList === null) throw new Error("There is no attached Linked List!");
-		this.current = this.attachedLinkedList.findKeyAtOffset(this.current, -delta);
+		if(!this.attachedLinkedList.has(this.current)) this.current = this.attachedLinkedList.findKeyAtOffset(this.neighbor.prev, -delta+1);
+		else this.current = this.attachedLinkedList.findKeyAtOffset(this.current, -delta);
+
 		return this.current;
 	}
 	moveNext(delta = 1)
 	{
 		if(this.attachedLinkedList === null) throw new Error("There is no attached Linked List!");
-		this.current = this.attachedLinkedList.findKeyAtOffset(this.current, delta);
+		if(!this.attachedLinkedList.has(this.current)) this.current = this.attachedLinkedList.findKeyAtOffset(this.neighbor.next, delta-1);
+		else this.current = this.attachedLinkedList.findKeyAtOffset(this.current, delta);
+
 		return this.current;
 	}
 	moveTo(id)
@@ -42,7 +56,7 @@ class PaginationCursor
 	*getDataIterator(num, offset=0)
 	{
 		if(this.attachedLinkedList === null) throw new Error("There is no attached Linked List!");
-		let cursor = this.current;
+		let cursor = this.attachedLinkedList.has(this.current) ? this.current : this.neighbor.next;
 		for(let i=0; i<num; i++)
 		{
 			yield cursor;
@@ -65,6 +79,7 @@ class PaginationCursor
 	}
 	findOffset(offset)
 	{
+		let cursor = this.attachedLinkedList.has(this.current) ? this.current : this.neighbor.next;
 		return this.attachedLinkedList.findKeyAtOffsetNoOverflow(this.current, offset);
 	}
 }

--- a/js/states/paginationCursor.js
+++ b/js/states/paginationCursor.js
@@ -27,7 +27,7 @@ class PaginationCursor
 	moveBefore(delta = 1)
 	{
 		if(this.attachedLinkedList === null) throw new Error("There is no attached Linked List!");
-		if(!this.attachedLinkedList.has(this.current)) this.current = this.attachedLinkedList.findKeyAtOffset(this.neighbor.prev, -delta+1);
+		if(this.isOutOfList()) this.current = this.attachedLinkedList.findKeyAtOffset(this.neighbor.prev, -delta+1);
 		else this.current = this.attachedLinkedList.findKeyAtOffset(this.current, -delta);
 
 		return this.current;
@@ -35,7 +35,7 @@ class PaginationCursor
 	moveNext(delta = 1)
 	{
 		if(this.attachedLinkedList === null) throw new Error("There is no attached Linked List!");
-		if(!this.attachedLinkedList.has(this.current)) this.current = this.attachedLinkedList.findKeyAtOffset(this.neighbor.next, delta-1);
+		if(this.isOutOfList()) this.current = this.attachedLinkedList.findKeyAtOffset(this.neighbor.next, delta-1);
 		else this.current = this.attachedLinkedList.findKeyAtOffset(this.current, delta);
 
 		return this.current;
@@ -80,8 +80,12 @@ class PaginationCursor
 	}
 	findOffset(offset)
 	{
-		let cursor = this.attachedLinkedList.has(this.current) ? this.current : this.neighbor.next;
-		return this.attachedLinkedList.findKeyAtOffsetNoOverflow(this.current, offset);
+		let cursor = this.isOutOfList() ? this.neighbor.next : this.current;
+		return this.attachedLinkedList.findKeyAtOffsetNoOverflow(cursor, offset);
+	}
+	isOutOfList()
+	{
+		return !this.attachedLinkedList.has(this.current);
 	}
 }
 

--- a/js/states/paginationCursor.js
+++ b/js/states/paginationCursor.js
@@ -17,23 +17,13 @@ class PaginationCursor
 	moveBefore(delta = 1)
 	{
 		if(this.attachedLinkedList === null) throw new Error("There is no attached Linked List!");
-		for(let i=0; i<delta; i++)
-		{
-			let before = this.attachedLinkedList.get(this.current).prev;
-			if(before === null) return;
-			this.current = before;
-		}
+		this.current = this.attachedLinkedList.findKeyAtOffset(this.current, -delta);
 		return this.current;
 	}
 	moveNext(delta = 1)
 	{
 		if(this.attachedLinkedList === null) throw new Error("There is no attached Linked List!");
-		for(let i=0; i<delta; i++)
-		{
-			let after = this.attachedLinkedList.get(this.current).next;
-			if(after === null) return;
-			this.current = after;
-		}
+		this.current = this.attachedLinkedList.findKeyAtOffset(this.current, delta);
 		return this.current;
 	}
 	moveTo(id)
@@ -43,7 +33,13 @@ class PaginationCursor
 		else this.current = this.attachedLinkedList.first;
 		return this.current;
 	}
-	*getDataIterator(num)
+	moveFirst()
+	{
+		if(this.attachedLinkedList === null) throw new Error("There is no attached Linked List!");
+		this.current = this.attachedLinkedList.first;
+		return this.current;
+	}
+	*getDataIterator(num, offset=0)
 	{
 		if(this.attachedLinkedList === null) throw new Error("There is no attached Linked List!");
 		let cursor = this.current;
@@ -55,9 +51,21 @@ class PaginationCursor
 			cursor = after;
 		}
 	}
-	getDataList(num)
+	getDataList(num, offset)
 	{
-		return [...this.getDataIterator(num)];
+		return [...this.getDataIterator(num, offset)];
+	}
+	getFirstKey()
+	{
+		return this.attachedLinkedList.first;
+	}
+	getLastKey()
+	{
+		return this.attachedLinkedList.last;
+	}
+	findOffset(offset)
+	{
+		return this.attachedLinkedList.findKeyAtOffset(this.current, offset);
 	}
 }
 

--- a/js/states/paginationCursor.js
+++ b/js/states/paginationCursor.js
@@ -65,7 +65,7 @@ class PaginationCursor
 	}
 	findOffset(offset)
 	{
-		return this.attachedLinkedList.findKeyAtOffset(this.current, offset);
+		return this.attachedLinkedList.findKeyAtOffsetNoOverflow(this.current, offset);
 	}
 }
 

--- a/js/states/paginationCursor.js
+++ b/js/states/paginationCursor.js
@@ -1,0 +1,64 @@
+class PaginationCursor
+{
+	constructor(linkedList = null)
+	{
+		this.attachedLinkedList = null;
+		this.current = null;
+		if(linkedList !== null) this.changeLinkedList(linkedList);
+	}
+	changeLinkedList(linkedList)
+	{
+		this.attachedLinkedList = linkedList;
+		if(!this.attachedLinkedList.has(this.current))
+		{
+			this.current = this.attachedLinkedList.first;
+		}
+	}
+	moveBefore(delta = 1)
+	{
+		if(this.attachedLinkedList === null) throw new Error("There is no attached Linked List!");
+		for(let i=0; i<delta; i++)
+		{
+			let before = this.attachedLinkedList.get(this.current).prev;
+			if(before === null) return;
+			this.current = before;
+		}
+		return this.current;
+	}
+	moveNext(delta = 1)
+	{
+		if(this.attachedLinkedList === null) throw new Error("There is no attached Linked List!");
+		for(let i=0; i<delta; i++)
+		{
+			let after = this.attachedLinkedList.get(this.current).next;
+			if(after === null) return;
+			this.current = after;
+		}
+		return this.current;
+	}
+	moveTo(id)
+	{
+		if(this.attachedLinkedList === null) throw new Error("There is no attached Linked List!");
+		if(this.attachedLinkedList.has(id)) this.current = id;
+		else this.current = this.attachedLinkedList.first;
+		return this.current;
+	}
+	*getDataIterator(num)
+	{
+		if(this.attachedLinkedList === null) throw new Error("There is no attached Linked List!");
+		let cursor = this.current;
+		for(let i=0; i<num; i++)
+		{
+			yield cursor;
+			let after = this.attachedLinkedList.get(cursor).next;
+			if(after === null) return;
+			cursor = after;
+		}
+	}
+	getDataList(num)
+	{
+		return [...this.getDataIterator(num)];
+	}
+}
+
+export default PaginationCursor;

--- a/js/states/paginationCursor.js
+++ b/js/states/paginationCursor.js
@@ -57,6 +57,7 @@ class PaginationCursor
 	{
 		if(this.attachedLinkedList === null) throw new Error("There is no attached Linked List!");
 		let cursor = this.attachedLinkedList.has(this.current) ? this.current : this.neighbor.next;
+		if(cursor === null) return;
 		for(let i=0; i<num; i++)
 		{
 			yield cursor;

--- a/js/states/state.js
+++ b/js/states/state.js
@@ -12,7 +12,7 @@ function State(initialValue, sideEffect=null)
 		if(this.value === newValue) return;
 		const oldValue = this.value;
 		this.value = newValue;
-		return oldValue;
+		stateBatchUpdater.__appendSideEffects(this.__sideEffects, newValue, oldValue);
 	}
 }
 

--- a/js/states/state.js
+++ b/js/states/state.js
@@ -1,27 +1,12 @@
-const stateBatchUpdater = {
-	pendingTasks: new Map(),
-	hasPendingTask: false,
-	callUpdate(state, newValue) {
-		this.pendingTasks.set( state, newValue );
-		if(this.hasPendingTask) return;
-		this.hasPendingTask = true;
-		requestAnimationFrame( ()=>{
-			for(let [st, nv] of this.pendingTasks)
-			{
-				st.__applyChange(nv);
-			}
-			this.pendingTasks.clear();
-			this.hasPendingTask = false;
-		} );
-	}
-};
+import stateBatchUpdater from "./stateBatchUpdater.js";
 
-function State(initialValue, sideEffect)
+function State(initialValue, sideEffect=null)
 {
-	if(typeof sideEffect !== "function") {
+	if(sideEffect !== null && typeof sideEffect !== "function") {
 		throw new Error("side effect must be function!");
 	}
-	this.__sideEffects = new Set([sideEffect]);
+	this.__sideEffects = new Set();
+	if( typeof sideEffect === "function" ) this.__sideEffects.add(sideEffect);
 	this.value = initialValue;
 	this.__applyChange = (newValue)=>{
 		if(this.value === newValue) return;

--- a/js/states/state.js
+++ b/js/states/state.js
@@ -5,8 +5,10 @@ function State(initialValue, sideEffect=null)
 	if(sideEffect !== null && typeof sideEffect !== "function") {
 		throw new Error("side effect must be function!");
 	}
+
 	this.__sideEffects = new Map();
 	if( typeof sideEffect === "function" ) this.__sideEffects.set(sideEffect, "default");
+
 	this.value = initialValue;
 	this.__applyChange = (newValue)=>{
 		if(this.value === newValue) return;

--- a/js/states/state.js
+++ b/js/states/state.js
@@ -5,17 +5,14 @@ function State(initialValue, sideEffect=null)
 	if(sideEffect !== null && typeof sideEffect !== "function") {
 		throw new Error("side effect must be function!");
 	}
-	this.__sideEffects = new Set();
-	if( typeof sideEffect === "function" ) this.__sideEffects.add(sideEffect);
+	this.__sideEffects = new Map();
+	if( typeof sideEffect === "function" ) this.__sideEffects.set(sideEffect, "default");
 	this.value = initialValue;
 	this.__applyChange = (newValue)=>{
 		if(this.value === newValue) return;
 		const oldValue = this.value;
 		this.value = newValue;
-		for(let func of this.__sideEffects)
-		{
-			func.call(this, newValue, oldValue);
-		}
+		return oldValue;
 	}
 }
 
@@ -24,9 +21,9 @@ State.prototype.change = function(newValue)
 	stateBatchUpdater.callUpdate(this, newValue);
 }
 
-State.prototype.addSideEffect = function(func)
+State.prototype.addSideEffect = function(func, key="default")
 {
-	this.__sideEffects.add(func);
+	this.__sideEffects.set(func, key);
 }
 
 State.prototype.removeSideEffect = function(func)

--- a/js/states/stateBatchUpdater.js
+++ b/js/states/stateBatchUpdater.js
@@ -14,9 +14,10 @@ const stateBatchUpdater = {
 			{
 				st.__applyChange(nv);
 			}
-			this.callSideEffects();
 			this.pendingTasks.clear();
 			this.hasPendingTask = false;
+
+			this.callSideEffects();
 		} );
 	},
 	// 저장된 모든 사이드이펙트에 대해, {func : [ {stateKey:newState}, {stateKey:oldState} ]}로 변경하는걸 수행

--- a/js/states/stateBatchUpdater.js
+++ b/js/states/stateBatchUpdater.js
@@ -1,0 +1,19 @@
+const stateBatchUpdater = {
+	pendingTasks: new Map(),
+	hasPendingTask: false,
+	callUpdate(state, newValue) {
+		this.pendingTasks.set( state, newValue );
+		if(this.hasPendingTask) return;
+		this.hasPendingTask = true;
+		requestAnimationFrame( ()=>{
+			for(let [st, nv] of this.pendingTasks)
+			{
+				st.__applyChange(nv);
+			}
+			this.pendingTasks.clear();
+			this.hasPendingTask = false;
+		} );
+	}
+};
+
+export default stateBatchUpdater;

--- a/js/states/stateBatchUpdater.js
+++ b/js/states/stateBatchUpdater.js
@@ -1,6 +1,7 @@
 const stateBatchUpdater = {
 	pendingTasks: new Map(),
 	hasPendingTask: false,
+	pendingSideEffects: new Map(),
 	callUpdate(state, newValue) {
 		this.pendingTasks.set( state, newValue );
 		if(this.hasPendingTask) return;
@@ -11,45 +12,52 @@ const stateBatchUpdater = {
 			let sideEffects = new Map();
 			for(let [st, nv] of this.pendingTasks)
 			{
-				let oldValue = st.__applyChange(nv);
-
-				// 저장된 모든 사이드이펙트에 대해, {func : [ {stateKey:newState}, {stateKey:oldState} ]}로 변경하는걸 수행
-				for(let [sideEffect, stateKey] of st.__sideEffects)
-				{
-					let newStates, oldStates;
-					if(sideEffects.has(sideEffect))
-					{
-						[newStates, oldStates] = sideEffects.get(sideEffect);
-					}
-					else
-					{
-						[newStates, oldStates] = [{}, {}];
-						sideEffects.set(sideEffect, [newStates, oldStates]);
-					}
-					newStates[stateKey] = nv;
-					oldStates[stateKey] = oldValue;
-				}
+				st.__applyChange(nv);
 			}
-			// 함수를 중복되지 않도록 실행한다.
-			for(let [func, stateDifferences] of sideEffects)
-			{
-				// 사이드이펙트의 key가 default이고 유일하면, 콜백함수에서 원시값으로 변경값을 참조할수있음
-
-				let stateDiffenecesArr = Object.keys(stateDifferences[0]);
-				if(stateDiffenecesArr.length === 1)
-				{
-					let onlyKey = stateDiffenecesArr[0];
-					if(onlyKey === "default") func(stateDifferences[0].default, stateDifferences[1].default);
-					else func(...stateDifferences);
-				}
-				else
-				{
-					func(...stateDifferences);
-				}
-			}
+			this.callSideEffects();
 			this.pendingTasks.clear();
 			this.hasPendingTask = false;
 		} );
+	},
+	// 저장된 모든 사이드이펙트에 대해, {func : [ {stateKey:newState}, {stateKey:oldState} ]}로 변경하는걸 수행
+	__appendSideEffects(stateSideEffects, newValue, oldValue)
+	{
+		for(let [sideEffect, stateKey] of stateSideEffects)
+		{
+			let newStates, oldStates;
+			if(this.pendingSideEffects.has(sideEffect))
+			{
+				[newStates, oldStates] = this.pendingSideEffects.get(sideEffect);
+			}
+			else
+			{
+				[newStates, oldStates] = [{}, {}];
+				this.pendingSideEffects.set(sideEffect, [newStates, oldStates]);
+			}
+			newStates[stateKey] = newValue;
+			oldStates[stateKey] = oldValue;
+		}
+	},
+	// 함수를 중복되지 않도록 실행한다.
+	callSideEffects()
+	{
+		for(let [func, stateDifferences] of this.pendingSideEffects)
+		{
+			// 사이드이펙트의 key가 default이고 유일하면, 콜백함수에서 원시값으로 변경값을 참조할수있음
+
+			let stateDiffenecesArr = Object.keys(stateDifferences[0]);
+			if(stateDiffenecesArr.length === 1)
+			{
+				let onlyKey = stateDiffenecesArr[0];
+				if(onlyKey === "default") func(stateDifferences[0].default, stateDifferences[1].default);
+				else func(...stateDifferences);
+			}
+			else
+			{
+				func(...stateDifferences);
+			}
+		}
+		this.pendingSideEffects.clear();
 	}
 };
 

--- a/js/states/stateBatchUpdater.js
+++ b/js/states/stateBatchUpdater.js
@@ -5,10 +5,47 @@ const stateBatchUpdater = {
 		this.pendingTasks.set( state, newValue );
 		if(this.hasPendingTask) return;
 		this.hasPendingTask = true;
+
+		// 다음 프레임에 상태를 변경하고 사이드이펙트를 실행시킨다.
 		requestAnimationFrame( ()=>{
+			let sideEffects = new Map();
 			for(let [st, nv] of this.pendingTasks)
 			{
-				st.__applyChange(nv);
+				let oldValue = st.__applyChange(nv);
+
+				// 저장된 모든 사이드이펙트에 대해, {func : [ {stateKey:newState}, {stateKey:oldState} ]}로 변경하는걸 수행
+				for(let [sideEffect, stateKey] of st.__sideEffects)
+				{
+					let newStates, oldStates;
+					if(sideEffects.has(sideEffect))
+					{
+						[newStates, oldStates] = sideEffects.get(sideEffect);
+					}
+					else
+					{
+						[newStates, oldStates] = [{}, {}];
+						sideEffects.set(sideEffect, [newStates, oldStates]);
+					}
+					newStates[stateKey] = nv;
+					oldStates[stateKey] = oldValue;
+				}
+			}
+			// 함수를 중복되지 않도록 실행한다.
+			for(let [func, stateDifferences] of sideEffects)
+			{
+				// 사이드이펙트의 key가 default이고 유일하면, 콜백함수에서 원시값으로 변경값을 참조할수있음
+
+				let stateDiffenecesArr = Object.keys(stateDifferences[0]);
+				if(stateDiffenecesArr.length === 1)
+				{
+					let onlyKey = stateDiffenecesArr[0];
+					if(onlyKey === "default") func(stateDifferences[0].default, stateDifferences[1].default);
+					else func(...stateDifferences);
+				}
+				else
+				{
+					func(...stateDifferences);
+				}
 			}
 			this.pendingTasks.clear();
 			this.hasPendingTask = false;

--- a/js/views/gridViewComponent.js
+++ b/js/views/gridViewComponent.js
@@ -1,0 +1,22 @@
+import db from "../rawData.js";
+import html from "../domParser.js";
+
+function GridViewComponent(pressList)
+{
+	const dom = html`<article class="gridContent">
+		${ pressList.map( pressId=>html`<div class="gridItem" data-unique-key="grid-item-${pressId}">
+			<img class="gridLogo" src="${db[pressId].logo}" alt="${db[pressId].name}">
+			<div class="subscribeHoverer">
+				<button class="subscribeButton" data-force-replace="true">
+					<svg class="icon" width="24" height="24" viewBox="0 0 24 24" fill="inherit" xmlns="http://www.w3.org/2000/svg">
+						<path d="M19 12.998H13V18.998H11V12.998H5V10.998H11V4.99799H13V10.998H19V12.998Z" fill="inherit"/>
+					</svg>
+				구독하기</button>
+			</div>
+		</div>` ) }
+	</article>`;
+
+	return dom;
+}
+
+export default GridViewComponent;

--- a/js/views/gridViewComponent.js
+++ b/js/views/gridViewComponent.js
@@ -1,17 +1,14 @@
 import db from "../rawData.js";
 import html from "../domParser.js";
+import SubscribeButton from "./subscribeButton.js";
 
-function GridViewComponent(pressList)
+function GridViewComponent(pressList, subscribeState)
 {
 	const dom = html`<article class="gridContent">
 		${ pressList.map( pressId=>html`<div class="gridItem" data-unique-key="grid-item-${pressId}">
 			<img class="gridLogo" src="${db[pressId].logo}" alt="${db[pressId].name}">
 			<div class="subscribeHoverer">
-				<button class="subscribeButton" data-force-replace="true">
-					<svg class="icon" width="24" height="24" viewBox="0 0 24 24" fill="inherit" xmlns="http://www.w3.org/2000/svg">
-						<path d="M19 12.998H13V18.998H11V12.998H5V10.998H11V4.99799H13V10.998H19V12.998Z" fill="inherit"/>
-					</svg>
-				구독하기</button>
+				${SubscribeButton(pressId, subscribeState)}
 			</div>
 		</div>` ) }
 	</article>`;

--- a/js/views/listContentComponent.js
+++ b/js/views/listContentComponent.js
@@ -1,6 +1,6 @@
 import db from "../rawData.js";
 import html from "../domParser.js";
-//import subscribeState from "./subscribeState.js";
+import SubscribeButton from "./subscribeButton.js";
 
 function getDateFormat(dateMillis)
 {
@@ -14,7 +14,7 @@ function getDateFormat(dateMillis)
 	return `${year}-${month}-${day} ${hour}:${minute}`;
 }
 
-function ListContentComponent(pressId)
+function ListContentComponent(pressId, subscribeState)
 {
 	const {name, logo, lastEditDate, headArticle, articleList} = db[pressId];
 
@@ -23,11 +23,7 @@ function ListContentComponent(pressId)
 		<div class="contentHeader">
 			<img src="${logo}" alt="${name}" class="logoImage" />
 			<p class="lastEditDate">${getDateFormat(lastEditDate)} 편집</p>
-			<button class="subscribeButton" data-force-replace="true">
-				<svg class="icon" width="24" height="24" viewBox="0 0 24 24" fill="inherit" xmlns="http://www.w3.org/2000/svg">
-					<path d="M19 12.998H13V18.998H11V12.998H5V10.998H11V4.99799H13V10.998H19V12.998Z" fill="inherit"/>
-				</svg>
-			구독하기</button>
+			${SubscribeButton(pressId, subscribeState)}
 		</div>
 		<div class="contentBody">
 			<div class="headlineArticle">
@@ -44,12 +40,6 @@ function ListContentComponent(pressId)
 			</ul>
 		</div>
 	</article>`;
-
-	const subscButton = dom.querySelector(".subscribeButton");
-	subscButton.addEventListener( "click", ()=>{
-		console.log(pressId);
-		//subscribePopup(pressId);
-	} );
 
 	return dom;
 }

--- a/js/views/listContentComponent.js
+++ b/js/views/listContentComponent.js
@@ -36,7 +36,7 @@ function ListContentComponent(pressId)
 			</div>
 			<ul class="articleList">
 				${
-					articleList.slice(0,6).map( (title)=>html`<li>${title}</li>`)
+					articleList.slice(0,6).map( (title, i)=>html`<li data-unique-key="article-slice-${i}">${title}</li>`)
 				}
 				<p class="articleFooter" data-unique-key="article-footer">${name} 언론사에서 직접 편집한 뉴스입니다.</p>
 			</ul>

--- a/js/views/listContentComponent.js
+++ b/js/views/listContentComponent.js
@@ -31,7 +31,9 @@ function ListContentComponent(pressId)
 		</div>
 		<div class="contentBody">
 			<div class="headlineArticle">
-				<img src="${headArticle.img}" alt="${headArticle.title}">
+				<div class="headlineImgWrapper">
+					<img src="${headArticle.img}" alt="${headArticle.title}">
+				</div>
 				<p>${headArticle.title}</p>
 			</div>
 			<ul class="articleList">

--- a/js/views/listContentComponent.js
+++ b/js/views/listContentComponent.js
@@ -21,14 +21,14 @@ function ListContentComponent(pressId, subscribeState)
 	const dom = html`
 	<article class="listContent">
 		<div class="contentHeader">
-			<img src="${logo}" alt="${name}" class="logoImage" />
+			<img src="${logo}" alt="${name}" class="logoImage" loading="lazy" />
 			<p class="lastEditDate">${getDateFormat(lastEditDate)} 편집</p>
 			${SubscribeButton(pressId, subscribeState)}
 		</div>
 		<div class="contentBody">
 			<div class="headlineArticle">
 				<div class="headlineImgWrapper">
-					<img src="${headArticle.img}" alt="${headArticle.title}">
+					<img src="${headArticle.img}" alt="${headArticle.title}" loading="lazy">
 				</div>
 				<p>${headArticle.title}</p>
 			</div>

--- a/js/views/listHeaderAllComponent.js
+++ b/js/views/listHeaderAllComponent.js
@@ -7,11 +7,12 @@ function ListHeaderAllComponent(pressId, moveToFunc, listData, listMetaData)
 	const items = listMetaData.map( ({pages, offset, name, destination})=>{
 		if(offset <= index && offset+pages > index) {
 			return html`<div class="listItem selected" 
-				style="--page-progress: ${(index-offset) / pages}" 
+				style="--page-progress: ${index-offset+1}; --page-all: ${pages}" 
 				data-unique-key="all-pagination-${name}" 
 				data-move-destination="${destination}"
 			>
 				${name}
+				<span class="pagination-tooltip"><span class="white">${index-offset+1}</span> / ${pages}</span>
 			</div>`;
 		}
 		return html`<div class="listItem" data-unique-key="all-pagination-${name}" data-move-destination="${destination}">${name}</div>`;

--- a/js/views/listHeaderAllComponent.js
+++ b/js/views/listHeaderAllComponent.js
@@ -1,0 +1,20 @@
+function ListHeaderAllComponent(currentPageState, paginationData)
+{
+	const page = currentPageState.value;
+
+	const items = paginationData.map( ({allPage, indexOffset, name})=>{
+		if(indexOffset <= page && indexOffset+allPage > page) {
+			return html`<div class="listItem selected" style="--page-progress: ${(page-indexOffset) / allPage}" data-unique-key="all-pagination-${name}">
+				${name}
+			</div>`;
+		}
+		return html`<div class="listItem">${name}</div>`;
+	} );
+	items.forEach( (e, i)=>e.addEventListener("click", ()=>{
+		currentPageState.change( paginationData[i].indexOffset );
+	}) );
+
+	const dom = html`<nav class="listNav full-paged">${items}</nav>`;
+
+	return dom;
+}

--- a/js/views/listHeaderAllComponent.js
+++ b/js/views/listHeaderAllComponent.js
@@ -1,20 +1,31 @@
-function ListHeaderAllComponent(currentPageState, paginationData)
-{
-	const page = currentPageState.value;
+import html from "../domParser.js";
 
-	const items = paginationData.map( ({allPage, indexOffset, name})=>{
-		if(indexOffset <= page && indexOffset+allPage > page) {
-			return html`<div class="listItem selected" style="--page-progress: ${(page-indexOffset) / allPage}" data-unique-key="all-pagination-${name}">
+function ListHeaderAllComponent(pressId, moveToFunc, listData, listMetaData)
+{
+	const index = listData.indexOf(pressId);
+
+	const items = listMetaData.map( ({pages, offset, name, destination})=>{
+		if(offset <= index && offset+pages > index) {
+			return html`<div class="listItem selected" 
+				style="--page-progress: ${(index-offset) / pages}" 
+				data-unique-key="all-pagination-${name}" 
+				data-move-destination="${destination}"
+			>
 				${name}
 			</div>`;
 		}
-		return html`<div class="listItem">${name}</div>`;
+		return html`<div class="listItem" data-unique-key="all-pagination-${name}" data-move-destination="${destination}">${name}</div>`;
 	} );
-	items.forEach( (e, i)=>e.addEventListener("click", ()=>{
-		currentPageState.change( paginationData[i].indexOffset );
-	}) );
 
-	const dom = html`<nav class="listNav full-paged">${items}</nav>`;
+	const dom = html`<nav class="listNav full-paged" data-unique-key="list-view-header">${items}</nav>`;
+
+	dom.addEventListener( "click", (e)=>{
+		const button = e.target.closest(".listItem");
+		if(button === null) return;
+		moveToFunc(button.dataset.moveDestination);
+	} )
 
 	return dom;
 }
+
+export default ListHeaderAllComponent;

--- a/js/views/mainView.js
+++ b/js/views/mainView.js
@@ -2,20 +2,29 @@ import mountLeftSelector from "./mountLeftSelector.js";
 import mountRightSelector from "./mountRightSelector.js";
 import html from "../domParser.js";
 import ListContentComponent from "./listContentComponent.js";
+//import ListHeaderAllComponent from "./listHeaderAllComponent.js";
 import applyDiff from "../diffing.js";
 
-function mountView(el, data)
+function ListComponent(pressId)
 {
-	//const el = document.getElementById("newsSection");
-	const subscTypeState = mountLeftSelector();
-	const viewTypeState = mountRightSelector();
+	// const pressId = paginationState.value === 1 ? "현대방송" : "대구지역신문";
+	// let header = ListHeaderAllComponent(paginationState, [{allPage:5, indexOffset:0, name:"종합"}, {allPage:3, indexOffset:5, name:"합성"}]);
+	// return html`${header}${ListContentComponent(pressId)}`;
+	return ListContentComponent(pressId);
+}
 
-	viewTypeState.addSideEffect( (state)=>{
-		if(state === 1) applyDiff(el, ListContentComponent("현대방송"));
-		else applyDiff(el, ListContentComponent("대구지역신문"));
-	} );
+function mountView(state, reducer, metadata)
+{
+	const el = document.getElementById("newsSection");
 
-	el.appendChild(ListContentComponent("현대방송"));
+	function render()
+	{
+		if(state.viewType.value === "grid") applyDiff(el, html`<div>Grid View</div>`);
+		else applyDiff(el, ListComponent(state.cursor.state.value));
+	}
+
+	state.viewType.addSideEffect(render);
+	state.cursor.addSideEffect(render);
 }
 
 export default mountView;

--- a/js/views/mainView.js
+++ b/js/views/mainView.js
@@ -24,7 +24,6 @@ function ListComponent(state, reducer, fullList, metadata)
 
 function mountView(state, reducer, fullList, metadata)
 {
-	console.log(fullList, metadata);
 	const el = document.getElementById("newsSection");
 
 	function render(current)
@@ -33,6 +32,7 @@ function mountView(state, reducer, fullList, metadata)
 		else applyDiff(el, ListComponent(state, reducer, fullList, metadata));
 	}
 
+	state.subFilter.addSideEffect(render, "subFilter");
 	state.viewType.addSideEffect(render, "viewType");
 	state.cursor.addSideEffect(render, "cursor");
 }

--- a/js/views/mainView.js
+++ b/js/views/mainView.js
@@ -19,6 +19,7 @@ function mountView(state, reducer, metadata)
 
 	function render()
 	{
+		console.log("render call");
 		if(state.viewType.value === "grid") applyDiff(el, html`<div>Grid View</div>`);
 		else applyDiff(el, ListComponent(state.cursor.state.value));
 	}

--- a/js/views/mainView.js
+++ b/js/views/mainView.js
@@ -2,25 +2,32 @@ import mountLeftSelector from "./mountLeftSelector.js";
 import mountRightSelector from "./mountRightSelector.js";
 import html from "../domParser.js";
 import ListContentComponent from "./listContentComponent.js";
-//import ListHeaderAllComponent from "./listHeaderAllComponent.js";
+import ListHeaderAllComponent from "./listHeaderAllComponent.js";
 import applyDiff from "../diffing.js";
 
-function ListComponent(pressId)
+function ListComponent(pressId, reducer, fullList, metadata)
 {
+	if(pressId === null) return html`<div>없어요 구독한게</div>`;
+
 	// const pressId = paginationState.value === 1 ? "현대방송" : "대구지역신문";
 	// let header = ListHeaderAllComponent(paginationState, [{allPage:5, indexOffset:0, name:"종합"}, {allPage:3, indexOffset:5, name:"합성"}]);
 	// return html`${header}${ListContentComponent(pressId)}`;
-	return ListContentComponent(pressId);
+
+	const header = ListHeaderAllComponent(pressId, reducer.moveTo, fullList, metadata);
+	const content = ListContentComponent(pressId);
+
+	return html`${header}${content}`
 }
 
-function mountView(state, reducer, metadata)
+function mountView(state, reducer, fullList, metadata)
 {
+	console.log(fullList, metadata);
 	const el = document.getElementById("newsSection");
 
 	function render(current)
 	{
 		if(state.viewType.value === "grid") applyDiff(el, html`<div>Grid View</div>`);
-		else applyDiff(el, ListComponent(state.cursor.state.value));
+		else applyDiff(el, ListComponent(state.cursor.value, reducer, fullList, metadata));
 	}
 
 	state.viewType.addSideEffect(render, "viewType");

--- a/js/views/mainView.js
+++ b/js/views/mainView.js
@@ -6,8 +6,10 @@ import ListHeaderAllComponent from "./listHeaderAllComponent.js";
 import GridViewComponent from "./gridViewComponent.js";
 import applyDiff from "../diffing.js";
 
-function ListComponent(pressId, reducer, fullList, metadata)
+function ListComponent(state, reducer, fullList, metadata)
 {
+	const pressId = state.cursor.value;
+
 	if(pressId === null) return html`<div>없어요 구독한게</div>`;
 
 	// const pressId = paginationState.value === 1 ? "현대방송" : "대구지역신문";
@@ -15,7 +17,7 @@ function ListComponent(pressId, reducer, fullList, metadata)
 	// return html`${header}${ListContentComponent(pressId)}`;
 
 	const header = ListHeaderAllComponent(pressId, reducer.moveTo, fullList, metadata);
-	const content = ListContentComponent(pressId);
+	const content = ListContentComponent(pressId, state.subList);
 
 	return html`${header}${content}`
 }
@@ -28,7 +30,7 @@ function mountView(state, reducer, fullList, metadata)
 	function render(current)
 	{
 		if(state.viewType.value === "grid") applyDiff(el, GridViewComponent(state.cursor.getDataList(24)));
-		else applyDiff(el, ListComponent(state.cursor.value, reducer, fullList, metadata));
+		else applyDiff(el, ListComponent(state, reducer, fullList, metadata));
 	}
 
 	state.viewType.addSideEffect(render, "viewType");

--- a/js/views/mainView.js
+++ b/js/views/mainView.js
@@ -3,6 +3,7 @@ import mountRightSelector from "./mountRightSelector.js";
 import html from "../domParser.js";
 import ListContentComponent from "./listContentComponent.js";
 import ListHeaderAllComponent from "./listHeaderAllComponent.js";
+import GridViewComponent from "./gridViewComponent.js";
 import applyDiff from "../diffing.js";
 
 function ListComponent(pressId, reducer, fullList, metadata)
@@ -26,7 +27,7 @@ function mountView(state, reducer, fullList, metadata)
 
 	function render(current)
 	{
-		if(state.viewType.value === "grid") applyDiff(el, html`<div>Grid View</div>`);
+		if(state.viewType.value === "grid") applyDiff(el, GridViewComponent(state.cursor.getDataList(24)));
 		else applyDiff(el, ListComponent(state.cursor.value, reducer, fullList, metadata));
 	}
 

--- a/js/views/mainView.js
+++ b/js/views/mainView.js
@@ -17,15 +17,14 @@ function mountView(state, reducer, metadata)
 {
 	const el = document.getElementById("newsSection");
 
-	function render()
+	function render(current)
 	{
-		console.log("render call");
 		if(state.viewType.value === "grid") applyDiff(el, html`<div>Grid View</div>`);
 		else applyDiff(el, ListComponent(state.cursor.state.value));
 	}
 
-	state.viewType.addSideEffect(render);
-	state.cursor.addSideEffect(render);
+	state.viewType.addSideEffect(render, "viewType");
+	state.cursor.addSideEffect(render, "cursor");
 }
 
 export default mountView;

--- a/js/views/mainView.js
+++ b/js/views/mainView.js
@@ -28,11 +28,12 @@ function mountView(state, reducer, fullList, metadata)
 
 	function render(current)
 	{
-		if(state.viewType.value === "grid") applyDiff(el, GridViewComponent(state.cursor.getDataList(24)));
+		if(state.viewType.value === "grid") applyDiff(el, GridViewComponent(state.cursor.getDataList(24), state.subList));
 		else applyDiff(el, ListComponent(state, reducer, fullList, metadata));
 	}
 
 	state.subFilter.addSideEffect(render, "subFilter");
+	state.subList.addSideEffect(render, "subList");
 	state.viewType.addSideEffect(render, "viewType");
 	state.cursor.addSideEffect(render, "cursor");
 }

--- a/js/views/mountLeftSelector.js
+++ b/js/views/mountLeftSelector.js
@@ -4,7 +4,7 @@ function mountLeftSelector(state, setFullView, setSubscribedView)
 	const subMediaSelector = document.getElementById("subMediaSelector");
 
 	state.addSideEffect( (newState)=>{
-		if(newState === 1) {
+		if(!newState) {
 			allMediaSelector.classList.add("selected");
 			subMediaSelector.classList.remove("selected");
 		}

--- a/js/views/mountLeftSelector.js
+++ b/js/views/mountLeftSelector.js
@@ -12,7 +12,7 @@ function mountLeftSelector(state, setFullView, setSubscribedView)
 			allMediaSelector.classList.remove("selected");
 			subMediaSelector.classList.add("selected");
 		}
-	} )
+	} );
 
 	allMediaSelector.addEventListener("click", setFullView);
 	subMediaSelector.addEventListener("click", setSubscribedView);

--- a/js/views/mountLeftSelector.js
+++ b/js/views/mountLeftSelector.js
@@ -1,11 +1,9 @@
-import State from "../state.js";
-
-function mountLeftSelector()
+function mountLeftSelector(state, setFullView, setSubscribedView)
 {
 	const allMediaSelector = document.getElementById("allMediaSelector");
 	const subMediaSelector = document.getElementById("subMediaSelector");
 
-	const state = new State(1, (newState)=>{
+	state.addSideEffect( (newState)=>{
 		if(newState === 1) {
 			allMediaSelector.classList.add("selected");
 			subMediaSelector.classList.remove("selected");
@@ -14,16 +12,10 @@ function mountLeftSelector()
 			allMediaSelector.classList.remove("selected");
 			subMediaSelector.classList.add("selected");
 		}
-	});
+	} )
 
-	allMediaSelector.addEventListener("click", ()=>{
-		state.change(1);
-	});
-	subMediaSelector.addEventListener("click", ()=>{
-		state.change(2);
-	});
-
-	return state;
+	allMediaSelector.addEventListener("click", setFullView);
+	subMediaSelector.addEventListener("click", setSubscribedView);
 }
 
 export default mountLeftSelector;

--- a/js/views/mountPageMoverSelector.js
+++ b/js/views/mountPageMoverSelector.js
@@ -3,9 +3,11 @@ function mountPageMoverSelector(state, reducers)
 	const leftMover = document.getElementById("leftMoveButton");
 	const rightMover = document.getElementById("rightMoveButton");
 
-	state.addSideEffect( (value)=>{
-		leftMover.classList.toggle("hidden", reducers.isFirstPage());
-		rightMover.classList.toggle("hidden", reducers.isLastPage());
+	state.isFirstPage.addSideEffect( (value)=>{
+		leftMover.classList.toggle("hidden", value);
+	} );
+	state.isLastPage.addSideEffect( (value)=>{
+		rightMover.classList.toggle("hidden", value);
 	} );
 
 	leftMover.addEventListener("click", ()=>reducers.moveLeft());

--- a/js/views/mountPageMoverSelector.js
+++ b/js/views/mountPageMoverSelector.js
@@ -3,7 +3,7 @@ function mountPageMoverSelector(state, reducers)
 	const leftMover = document.getElementById("leftMoveButton");
 	const rightMover = document.getElementById("rightMoveButton");
 
-	state.addSideEffect( ()=>{
+	state.addSideEffect( (value)=>{
 		leftMover.classList.toggle("hidden", reducers.isFirstPage());
 		rightMover.classList.toggle("hidden", reducers.isLastPage());
 	} );

--- a/js/views/mountPageMoverSelector.js
+++ b/js/views/mountPageMoverSelector.js
@@ -1,0 +1,15 @@
+function mountPageMoverSelector(state, reducers)
+{
+	const leftMover = document.getElementById("leftMoveButton");
+	const rightMover = document.getElementById("rightMoveButton");
+
+	state.addSideEffect( ()=>{
+		leftMover.classList.toggle("hidden", reducers.isFirstPage());
+		rightMover.classList.toggle("hidden", reducers.isLastPage());
+	} );
+
+	leftMover.addEventListener("click", ()=>reducers.moveLeft());
+	rightMover.addEventListener("click", ()=>reducers.moveRight());
+}
+
+export default mountPageMoverSelector;

--- a/js/views/mountRightSelector.js
+++ b/js/views/mountRightSelector.js
@@ -1,12 +1,10 @@
-import State from "../state.js";
-
-function mountRightSelector()
+function mountRightSelector(state, setListView, setGridView)
 {
 	const listSelector = document.getElementById("listSelector");
 	const gridSelector = document.getElementById("gridSelector");
 
-	const state = new State(1, (newState)=>{
-		if(newState === 1) {
+	state.addSideEffect( (newState)=>{
+		if(newState === "list") {
 			listSelector.classList.add("selected");
 			gridSelector.classList.remove("selected");
 		}
@@ -14,16 +12,10 @@ function mountRightSelector()
 			listSelector.classList.remove("selected");
 			gridSelector.classList.add("selected");
 		}
-	});
+	} );
 
-	listSelector.addEventListener("click", ()=>{
-		state.change(1);
-	});
-	gridSelector.addEventListener("click", ()=>{
-		state.change(2);
-	});
-
-	return state;
+	listSelector.addEventListener("click", setListView);
+	gridSelector.addEventListener("click", setGridView);
 }
 
 export default mountRightSelector;

--- a/js/views/subscribeButton.js
+++ b/js/views/subscribeButton.js
@@ -1,0 +1,25 @@
+import html from "../domParser.js";
+
+const addIcon = html`<svg class="icon" width="24" height="24" viewBox="0 0 24 24" fill="inherit" xmlns="http://www.w3.org/2000/svg">
+	<path d="M19 12.998H13V18.998H11V12.998H5V10.998H11V4.99799H13V10.998H19V12.998Z" fill="inherit"/>
+</svg>`;
+const deleteIcon = html`<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path d="M7.2 18L6 16.8L10.8 12L6 7.2L7.2 6L12 10.8L16.8 6L18 7.2L13.2 12L18 16.8L16.8 18L12 13.2L7.2 18Z" fill="#14212B"/>
+</svg>`;
+
+function SubscribeButton(pressId, subList)
+{
+	const dom = html`<button class="subscribeButton" data-force-replace="true" data-unique-key="subscribe-button-${pressId}">
+		${!subList.has(pressId) ? addIcon : deleteIcon}${!subList.has(pressId) ? "구독하기" : ""}
+	</button>`
+
+	dom.addEventListener( "click", ()=>{
+		if(!subList.has(pressId)) subList.add(pressId);
+		else subList.delete(pressId);
+		// subscribePopup(pressId);
+	} );
+
+	return dom;
+}
+
+export default SubscribeButton;

--- a/js/views/subscribeButton.js
+++ b/js/views/subscribeButton.js
@@ -26,10 +26,10 @@ function SubscribeButton(pressId, subList)
 		// subscribePopup(pressId);
 	} );
 
-	subList.addSideEffect( (after, before)=>{
-		if(after.includes(pressId) && !before.includes(pressId)) applyDiff(dom, SubscribeButtonInner(true));
-		else if(before.includes(pressId) && !after.includes(pressId)) applyDiff(dom, SubscribeButtonInner(false));
-	} );
+	// subList.addSideEffect( (after, before)=>{
+	// 	if(after.includes(pressId) && !before.includes(pressId)) applyDiff(dom, SubscribeButtonInner(true));
+	// 	else if(before.includes(pressId) && !after.includes(pressId)) applyDiff(dom, SubscribeButtonInner(false));
+	// } );
 
 	return dom;
 }

--- a/js/views/subscribeButton.js
+++ b/js/views/subscribeButton.js
@@ -15,12 +15,13 @@ function SubscribeButtonInner(isSubbed)
 
 function SubscribeButton(pressId, subList)
 {
+	const prevCache = subList.getPrev(pressId);
 	const dom = html`<button class="subscribeButton" data-force-replace="true" data-unique-key="subscribe-button-${pressId}">
 		${SubscribeButtonInner(subList.has(pressId))}
 	</button>`
 
 	dom.addEventListener( "click", ()=>{
-		if(!subList.has(pressId)) subList.add(pressId);
+		if(!subList.has(pressId)) subList.add(pressId, prevCache);
 		else subList.delete(pressId);
 		// subscribePopup(pressId);
 	} );

--- a/js/views/subscribeButton.js
+++ b/js/views/subscribeButton.js
@@ -1,22 +1,33 @@
 import html from "../domParser.js";
+import applyDiff from "../diffing.js";
 
-const addIcon = html`<svg class="icon" width="24" height="24" viewBox="0 0 24 24" fill="inherit" xmlns="http://www.w3.org/2000/svg">
-	<path d="M19 12.998H13V18.998H11V12.998H5V10.998H11V4.99799H13V10.998H19V12.998Z" fill="inherit"/>
-</svg>`;
-const deleteIcon = html`<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<path d="M7.2 18L6 16.8L10.8 12L6 7.2L7.2 6L12 10.8L16.8 6L18 7.2L13.2 12L18 16.8L16.8 18L12 13.2L7.2 18Z" fill="#14212B"/>
-</svg>`;
+function SubscribeButtonInner(isSubbed)
+{
+	const addIcon = html`<svg class="icon" width="24" height="24" viewBox="0 0 24 24" fill="inherit" xmlns="http://www.w3.org/2000/svg">
+		<path d="M19 12.998H13V18.998H11V12.998H5V10.998H11V4.99799H13V10.998H19V12.998Z" fill="inherit"/>
+	</svg>`;
+	const deleteIcon = html`<svg class="icon" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path d="M7.2 18L6 16.8L10.8 12L6 7.2L7.2 6L12 10.8L16.8 6L18 7.2L13.2 12L18 16.8L16.8 18L12 13.2L7.2 18Z" fill="inherit"/>
+	</svg>`;
+	if(!isSubbed) return html`${addIcon}<span>구독하기</span>`;
+	return deleteIcon;
+}
 
 function SubscribeButton(pressId, subList)
 {
 	const dom = html`<button class="subscribeButton" data-force-replace="true" data-unique-key="subscribe-button-${pressId}">
-		${!subList.has(pressId) ? addIcon : deleteIcon}${!subList.has(pressId) ? "구독하기" : ""}
+		${SubscribeButtonInner(subList.has(pressId))}
 	</button>`
 
 	dom.addEventListener( "click", ()=>{
 		if(!subList.has(pressId)) subList.add(pressId);
 		else subList.delete(pressId);
 		// subscribePopup(pressId);
+	} );
+
+	subList.addSideEffect( (after, before)=>{
+		if(after.includes(pressId) && !before.includes(pressId)) applyDiff(dom, SubscribeButtonInner(true));
+		else if(before.includes(pressId) && !after.includes(pressId)) applyDiff(dom, SubscribeButtonInner(false));
 	} );
 
 	return dom;

--- a/style.css
+++ b/style.css
@@ -235,6 +235,54 @@ ul {
 	pointer-events: none;
 }
 
+.listNav {
+	width: 100%;
+    height: 40px;
+    overflow: hidden;
+    background-color: var(--surface-alt);
+    display: flex;
+    align-items: center;
+    box-sizing: border-box;
+    border-bottom: 1px solid var(--border-default);
+}
+
+.listItem {
+	position: relative;
+	height: 100%;
+	padding: 0px 16px;
+	display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.875rem;
+    color: var(--text-weak);
+    transition: background-color 0.3s, color 0.3s;
+}
+
+.listItem:hover {
+	background-color: var(--surface-brand-default);
+	color: var(--text-white-default);
+}
+
+.listItem.selected {
+	--page-linear-grad : calc(var(--page-progress) / var(--page-all)* 100%);
+	background: linear-gradient(90deg, 
+		var(--surface-brand-default) var(--page-linear-grad), 
+		var(--surface-brand-alt) var(--page-linear-grad)
+	);
+	color: var(--text-white-default);
+	font-weight: 700;
+	padding-right: 80px;
+}
+
+.pagination-tooltip {
+	color: var(--text-white-weak);
+	position: absolute;
+	right: 16px;
+}
+.pagination-tooltip > .white {
+	color: var(--text-white-default);
+}
+
 .listContent {
 	width: 100%;
 	display: flex;

--- a/style.css
+++ b/style.css
@@ -382,3 +382,53 @@ ul {
 	color: var(--text-weak);
 }
 
+
+.gridContent {
+	width: 100%;
+	height: 100%;
+	display: grid;
+	grid-template-columns: repeat(6, 16.66666666%);
+	grid-auto-rows: 25%;
+	align-items: center;
+	justify-items: center;
+}
+
+.gridItem {
+	width: 100%;
+	height: 100%;
+	position: relative;
+	box-sizing: border-box;
+}
+
+.gridItem:not(:nth-child(6n)) {
+	border-right: 1px solid var(--border-default);
+}
+.gridItem:not(:nth-child(n+19)) {
+	border-bottom: 1px solid var(--border-default);
+}
+
+.gridLogo {
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+	object-position: center;
+}
+
+.subscribeHoverer {
+	visibility: hidden;
+	width: 100%;
+	height: 100%;
+	position: absolute;
+	top: 0;
+	left: 0;
+	background-color: var(--surface-alt);
+	display: flex;
+	justify-content: center;
+    align-items: center;
+	pointer-events: none;
+}
+
+.gridItem:hover .subscribeHoverer {
+	visibility: visible;
+	pointer-events: auto;
+}

--- a/style.css
+++ b/style.css
@@ -340,8 +340,9 @@ ul {
 
 .subscribeButton {
 	display: flex;
+	height: 24px;
 	align-items: center;
-	padding: 2px 10px 2px 8px;
+	padding: 2px 8px;
 	gap: 2px;
 	border: 1px solid var(--border-default);
 	border-radius: 50px;
@@ -355,6 +356,10 @@ ul {
 	width: 12px;
 	height: 12px;
 	fill: var(--text-weak);
+}
+
+.subscribeButton > span {
+	margin-right: 4px;
 }
 
 .contentBody {

--- a/style.css
+++ b/style.css
@@ -201,11 +201,19 @@ ul {
 	}
 }
 
-#newsSection {
+.mainBoxWrapper {
+	position:relative;
+	overflow: hidden;
 	width: 100%;
 	height: 388px;
 	border: 1px solid var(--border-default);
 	box-sizing: border-box;
+}
+
+#newsSection {
+	width: 100%;
+	height: 100%;
+	position: relative;
 }
 
 .moveIcon {
@@ -264,14 +272,24 @@ ul {
 }
 
 .listItem.selected {
-	--page-linear-grad : calc(var(--page-progress) / var(--page-all)* 100%);
-	background: linear-gradient(90deg, 
-		var(--surface-brand-default) var(--page-linear-grad), 
-		var(--surface-brand-alt) var(--page-linear-grad)
-	);
+	--page-linear-grad : calc(var(--page-progress) / var(--page-all)* 50%);
+	overflow: hidden;
 	color: var(--text-white-default);
 	font-weight: 700;
 	padding-right: 80px;
+	z-index:0;
+}
+
+.listItem.selected::before {
+	content: "";
+	position: absolute;
+	left: -100%;
+	width: 200%;
+	height: 100%;
+	z-index: -1;
+	background: linear-gradient(90deg, var(--surface-brand-default) 50%, var(--surface-brand-alt) 50%);
+	transform: translateX(var(--page-linear-grad));
+	transition: transform 0.3s;
 }
 
 .pagination-tooltip {

--- a/style.css
+++ b/style.css
@@ -449,6 +449,7 @@ ul {
 	width: 100%;
 	height: 100%;
 	overflow: hidden;
+	object-fit: cover;
 	object-position: center;
 }
 

--- a/style.css
+++ b/style.css
@@ -210,10 +210,16 @@ ul {
 	box-sizing: border-box;
 }
 
-#newsSection {
+#newsSection, #modalSection {
 	width: 100%;
 	height: 100%;
-	position: relative;
+	position: absolute;
+	left: 0;
+	top: 0;
+}
+
+#modalSection {
+	pointer-events: none;
 }
 
 .moveIcon {

--- a/style.css
+++ b/style.css
@@ -365,11 +365,25 @@ ul {
 	gap: 16px;
 }
 
-.headlineArticle img {
+.headlineImgWrapper {
 	width: 320px;
 	height: 200px;
+	overflow: hidden;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}
+
+.headlineArticle img {
+	width: 100%;
+	height: 100%;
 	object-position: center;
 	object-fit: cover;
+	transition: transform 0.5s;
+}
+
+.headlineArticle img:hover {
+	transform: scale(1.2);
 }
 
 .headlineArticle p {

--- a/style.css
+++ b/style.css
@@ -230,6 +230,11 @@ ul {
 	right: -48px;
 }
 
+.moveIcon.hidden {
+	visibility: hidden;
+	pointer-events: none;
+}
+
 .listContent {
 	width: 100%;
 	display: flex;


### PR DESCRIPTION
## 7/4 한일
- 본격적인 상태관리 로직을 추가했습니다.
- 리스트 뷰의 페이지네이션을 구현했습니다.
- 그리드 뷰의 페이지네이션을 구현했습니다.
- 리스트 뷰의 상단 바 클릭 시 내비게이팅 기능을 구현했습니다.
- diffing 알고리즘 시 엘리먼트가 꼬이는 버그를 수정했습니다.

## 7/5 한일
- 상태관리 관련, 상태가 다른 상태를 변경하는 경우를 핸들링하는 부분을 추가했습니다.
  - 왼쪽과 오른쪽 이동 버튼은 cursor 상태와 viewType 상태 등 여러 상태에 따라 변화되는, isFirstPage 상태와 isLastPage 상태에 따라 달라집니다.
- 간단한 구독 기능을 구현했습니다.
- 상태와 사이드이펙트를 주입하는 부분을 함수로 구현해서, props drilling과 비슷한 문제가 존재했습니다.
  - 상태를 초기화하는 부분이 데이터 가공에 종속되어 있습니다.
- dom diffing algorithm의 자잘한 버그들을 수정했습니다.
  - 메모리에만 존재하는 dom 객체를 생성하는 방식으로 이용하고 있는데, 메모리에만 존재하는 dom에서 이미지를 불러올 때(ListContentComponent) 이미지를 로드하려고 하는 문제를 수정했습니다. (loading="lazy"를 이용)