### PR TITLE
07/08-마경미-데이터를 추가하고, 그에 맞게 프로퍼티, 액션을 수정해요

### DIFF
--- a/newsstand/assets/icons/plus.svg
+++ b/newsstand/assets/icons/plus.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.5 6.49902H6.5V9.49902H5.5V6.49902H2.5V5.49902H5.5V2.49902H6.5V5.49902H9.5V6.49902Z" fill="#879298"/>
+</svg>

--- a/newsstand/assets/icons/xmark.svg
+++ b/newsstand/assets/icons/xmark.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.6 9L3 8.4L5.4 6L3 3.6L3.6 3L6 5.4L8.4 3L9 3.6L6.6 6L9 8.4L8.4 9L6 6.6L3.6 9Z" fill="#879298"/>
+</svg>

--- a/newsstand/data/tabNewsData.js
+++ b/newsstand/data/tabNewsData.js
@@ -1,751 +1,751 @@
-// 수연님의 하루를 갈아 만든 데이터입니당 ^^...
-// 출처: 최수연
+  // 수연님의 하루를 갈아 만든 데이터입니당 ^^...
+  // 출처: 최수연
 
-export const TAB_NEWS_DATA = {
-  data: [
-    {
-      newsTabs: [
-        {
-          tabName: "종합/경제",
-          category: "comprehensive",
-          tabData: [
-            {
-              mediaName: "경향신문",
-              sourceLogo: "assets/news/logo/kyunghyang.svg",
-              newsDate: "2023.02.10. 12:34",
-              subscribe: "N",
-              mainNews: {
-                thumbnailImage:
-                  "https://img.khan.co.kr/news/2024/07/06/rcv.YNA.20240705.PYH2024070501770001300_P1.webp",
-                newsTitle:
-                  "민주당, 검찰총장에 “허세 부리지 말고 김 여사 수사나 제대로”",
-                url: "https://www.khan.co.kr/politics/assembly/article/202407061302001/",
+  export const TAB_NEWS_DATA = {
+    data: [
+      {
+        newsTabs: [
+          {
+            tabName: "종합/경제",
+            category: "comprehensive",
+            tabData: [
+              {
+                mediaName: "경향신문",
+                sourceLogo: "assets/news/logo/kyunghyang.svg",
+                newsDate: "2023.02.10. 12:34",
+                subscribe: "N",
+                mainNews: {
+                  thumbnailImage:
+                    "https://img.khan.co.kr/news/2024/07/06/rcv.YNA.20240705.PYH2024070501770001300_P1.webp",
+                  newsTitle:
+                    "민주당, 검찰총장에 “허세 부리지 말고 김 여사 수사나 제대로”",
+                  url: "https://www.khan.co.kr/politics/assembly/article/202407061302001/",
+                },
+                subNews: [
+                  {
+                    newsTitle:
+                      "일 자민당, 9월20일 총재 선거 검토…“기시다에 불출마 압력 커져”",
+                    url: "https://www.khan.co.kr/world/japan/article/202407061524001/",
+                  },
+                  {
+                    newsTitle:
+                      "중국서 2번째 큰 담수호 ‘둥팅호’ 제방 220ｍ 유실…주민 긴급 대피",
+                    url: "https://www.khan.co.kr/world/china/article/202407061643001/",
+                  },
+                  {
+                    newsTitle: "‘온건 개혁파’ 페제시키안, 이란 대선 승리",
+                    url: "https://www.khan.co.kr/world/mideast-africa/article/202407061256001/",
+                  },
+                  {
+                    newsTitle: "고장난 우산…버리면 쓰레기, 수리하면 애착 우산",
+                    url: "https://www.khan.co.kr/life/life-general/article/202407060900001/",
+                  },
+                  {
+                    newsTitle:
+                      "법원 “삼청교육대 ‘보호감호’ 피해자들에 국가 배상해야”",
+                    url: "https://www.khan.co.kr/national/national-general/article/202407061448001/",
+                  },
+                  {
+                    newsTitle:
+                      "경찰 수사심의위, ‘채상병 사건’ 임성근 전 사단장 불송치 의견",
+                    url: "https://khan.co.kr/politics/politics-general/article/202407060909001/",
+                  },
+                ],
               },
-              subNews: [
-                {
+              {
+                mediaName: "YTN",
+                sourceLogo: "assets/news/logo/ytn.svg",
+                newsDate: "2023.02.10. 11:11",
+                subscribe: "N",
+                mainNews: {
+                  thumbnailImage:
+                    "https://image.ytn.co.kr/general/jpg/2022/0413/202204131632445371_t.jpg",
                   newsTitle:
-                    "일 자민당, 9월20일 총재 선거 검토…“기시다에 불출마 압력 커져”",
-                  url: "https://www.khan.co.kr/world/japan/article/202407061524001/",
+                    '\'김 여사 문자\' 후폭풍 확산..."전대 개입" vs "해당 행위"',
+                  url: "https://www.ytn.co.kr/_cs/_ln_0101_202407061753597028_005.html",
                 },
-                {
-                  newsTitle:
-                    "중국서 2번째 큰 담수호 ‘둥팅호’ 제방 220ｍ 유실…주민 긴급 대피",
-                  url: "https://www.khan.co.kr/world/china/article/202407061643001/",
-                },
-                {
-                  newsTitle: "‘온건 개혁파’ 페제시키안, 이란 대선 승리",
-                  url: "https://www.khan.co.kr/world/mideast-africa/article/202407061256001/",
-                },
-                {
-                  newsTitle: "고장난 우산…버리면 쓰레기, 수리하면 애착 우산",
-                  url: "https://www.khan.co.kr/life/life-general/article/202407060900001/",
-                },
-                {
-                  newsTitle:
-                    "법원 “삼청교육대 ‘보호감호’ 피해자들에 국가 배상해야”",
-                  url: "https://www.khan.co.kr/national/national-general/article/202407061448001/",
-                },
-                {
-                  newsTitle:
-                    "경찰 수사심의위, ‘채상병 사건’ 임성근 전 사단장 불송치 의견",
-                  url: "https://khan.co.kr/politics/politics-general/article/202407060909001/",
-                },
-              ],
-            },
-            {
-              mediaName: "YTN",
-              sourceLogo: "assets/news/logo/ytn.svg",
-              newsDate: "2023.02.10. 11:11",
-              subscribe: "N",
-              mainNews: {
-                thumbnailImage:
-                  "https://image.ytn.co.kr/general/jpg/2022/0413/202204131632445371_t.jpg",
-                newsTitle:
-                  '\'김 여사 문자\' 후폭풍 확산..."전대 개입" vs "해당 행위"',
-                url: "https://www.ytn.co.kr/_cs/_ln_0101_202407061753597028_005.html",
+                subNews: [
+                  {
+                    newsTitle:
+                      '식을 줄 모르는 푸바오 신드롬..."정치적 해석은 문제"',
+                    url: "https://www.ytn.co.kr/_cs/_ln_0106_202407061046567285_005.html",
+                  },
+                  {
+                    newsTitle:
+                      "'시청역 역주행 차량' 사고 이력만 6번...향후 수사는?",
+                    url: "https://www.ytn.co.kr/_cs/_ln_0103_202407061044130005_005.html",
+                  },
+                  {
+                    newsTitle:
+                      '허웅 정당방위 주장에 "양측 모두 폭행으로 처벌 가능"',
+                    url: "https://www.ytn.co.kr/_cs/_ln_0103_202407061255278223_005.html",
+                  },
+                  {
+                    newsTitle:
+                      "크로아티아 한국 관광객↑...동포 자영업자들도 기대감",
+                    url: "https://www.ytn.co.kr/_cs/_ln_0104_202407061124456629_005.html",
+                  },
+                  {
+                    newsTitle: "부산 해수욕장 전면 개장...해무·파도에 입수 통제",
+                    url: "https://www.ytn.co.kr/_cs/_ln_0115_202407061555440602_005.html",
+                  },
+                  {
+                    newsTitle: "러시아, 우크라이나 에너지 시설 공격 재개",
+                    url: "https://www.ytn.co.kr/_cs/_ln_0104_202407061738147756_005.html",
+                  },
+                ],
               },
-              subNews: [
-                {
-                  newsTitle:
-                    '식을 줄 모르는 푸바오 신드롬..."정치적 해석은 문제"',
-                  url: "https://www.ytn.co.kr/_cs/_ln_0106_202407061046567285_005.html",
+              {
+                mediaName: "SBSBiz",
+                sourceLogo: "assets/news/logo/sbsBiz.svg",
+                newsDate: "2023.02.10. 11:11",
+                subscribe: "Y",
+                mainNews: {
+                  thumbnailImage:
+                    "https://img.sbs.co.kr/newimg/news/20240706/201954883_1280.jpg",
+                  newsTitle: "서울역 인근서 고령 운전자 차량 돌진…행인 2명 치어",
+                  url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007711972",
                 },
-                {
-                  newsTitle:
-                    "'시청역 역주행 차량' 사고 이력만 6번...향후 수사는?",
-                  url: "https://www.ytn.co.kr/_cs/_ln_0103_202407061044130005_005.html",
-                },
-                {
-                  newsTitle:
-                    '허웅 정당방위 주장에 "양측 모두 폭행으로 처벌 가능"',
-                  url: "https://www.ytn.co.kr/_cs/_ln_0103_202407061255278223_005.html",
-                },
-                {
-                  newsTitle:
-                    "크로아티아 한국 관광객↑...동포 자영업자들도 기대감",
-                  url: "https://www.ytn.co.kr/_cs/_ln_0104_202407061124456629_005.html",
-                },
-                {
-                  newsTitle: "부산 해수욕장 전면 개장...해무·파도에 입수 통제",
-                  url: "https://www.ytn.co.kr/_cs/_ln_0115_202407061555440602_005.html",
-                },
-                {
-                  newsTitle: "러시아, 우크라이나 에너지 시설 공격 재개",
-                  url: "https://www.ytn.co.kr/_cs/_ln_0104_202407061738147756_005.html",
-                },
-              ],
-            },
-            {
-              mediaName: "SBSBiz",
-              sourceLogo: "assets/news/logo/sbsBiz.svg",
-              newsDate: "2023.02.10. 11:11",
-              subscribe: "Y",
-              mainNews: {
-                thumbnailImage:
-                  "https://img.sbs.co.kr/newimg/news/20240706/201954883_1280.jpg",
-                newsTitle: "서울역 인근서 고령 운전자 차량 돌진…행인 2명 치어",
-                url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007711972",
+                subNews: [
+                  {
+                    newsTitle:
+                      "코레일 서울 본부서 화재 완진…인근 도로 한때 전면 통제",
+                    url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007712027",
+                  },
+                  {
+                    newsTitle:
+                      "이란 대선, 무명의 '개혁파' 페제시키안 당선…54% 득표",
+                    url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007711980",
+                  },
+                  {
+                    newsTitle:
+                      "민주, 경찰 '임성근 불송치' 의견에 \"대통령 입맛에 맞춘 요식 행위\"",
+                    url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007712009",
+                  },
+                  {
+                    newsTitle: '"역주행인 줄 몰랐다"…충돌 직전에야 "어, 어!"',
+                    url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007711584",
+                  },
+                  {
+                    newsTitle: '"드디어 사고 났다" SNS 대화방서 환호…53명 검거',
+                    url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007711595",
+                  },
+                  {
+                    newsTitle:
+                      "울산 '식수원' 회야댐 상류서 물고기 수십마리 잇단 폐사",
+                    url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007712071",
+                  },
+                ],
               },
-              subNews: [
-                {
+            ],
+          },
+          {
+            tabName: "방송/통신",
+            category: "broadcast",
+            tabData: [
+              {
+                mediaName: "매일경제",
+                sourceLogo: "assets/news/logo/maeil.svg",
+                newsDate: "2023.02.10. 20:27",
+                subscribe: "N",
+                mainNews: {
+                  thumbnailImage:
+                    "https://wimg.mk.co.kr/news/cms/202407/06/news-p.v1.20240706.fd08c99031b04720a87b4cc7897f4fc2_P1.jpg",
                   newsTitle:
-                    "코레일 서울 본부서 화재 완진…인근 도로 한때 전면 통제",
-                  url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007712027",
+                    "“해변이 온 통 피바다”…섬에 놀러왔다 상어에 물린 美엄마 ‘끔찍’",
+                  url: "https://www.mk.co.kr/news/world/11060549",
                 },
-                {
-                  newsTitle:
-                    "이란 대선, 무명의 '개혁파' 페제시키안 당선…54% 득표",
-                  url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007711980",
-                },
-                {
-                  newsTitle:
-                    "민주, 경찰 '임성근 불송치' 의견에 \"대통령 입맛에 맞춘 요식 행위\"",
-                  url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007712009",
-                },
-                {
-                  newsTitle: '"역주행인 줄 몰랐다"…충돌 직전에야 "어, 어!"',
-                  url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007711584",
-                },
-                {
-                  newsTitle: '"드디어 사고 났다" SNS 대화방서 환호…53명 검거',
-                  url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007711595",
-                },
-                {
-                  newsTitle:
-                    "울산 '식수원' 회야댐 상류서 물고기 수십마리 잇단 폐사",
-                  url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007712071",
-                },
-              ],
-            },
-          ],
-        },
-        {
-          tabName: "방송/통신",
-          category: "broadcast",
-          tabData: [
-            {
-              mediaName: "매일경제",
-              sourceLogo: "assets/news/logo/maeil.svg",
-              newsDate: "2023.02.10. 20:27",
-              subscribe: "N",
-              mainNews: {
-                thumbnailImage:
-                  "https://wimg.mk.co.kr/news/cms/202407/06/news-p.v1.20240706.fd08c99031b04720a87b4cc7897f4fc2_P1.jpg",
-                newsTitle:
-                  "“해변이 온 통 피바다”…섬에 놀러왔다 상어에 물린 美엄마 ‘끔찍’",
-                url: "https://www.mk.co.kr/news/world/11060549",
+                subNews: [
+                  {
+                    newsTitle:
+                      "폭염에 이틀째 정전이라니 어쩌나…410가구 아파트 주민 불편",
+                    url: "https://www.mk.co.kr/news/society/11060544",
+                  },
+                  {
+                    newsTitle:
+                      "“차라리 알바를 하고 말지”…9급 공무원 초임 월급보니 ‘충격’",
+                    url: "https://www.mk.co.kr/news/society/11060462",
+                  },
+                  {
+                    newsTitle:
+                      "“가서 앉아있으면 되나”…현금 5천만원 발견된 아파트 화단서 또 나왔다",
+                    url: "https://www.mk.co.kr/news/society/11060440",
+                  },
+                  {
+                    newsTitle:
+                      "“몸에서 냄새 나잖아”…직장 동료 세탁기에 강제로 넣고 돌린 日남성",
+                    url: "https://www.mk.co.kr/news/world/11060523",
+                  },
+                  {
+                    newsTitle:
+                      "“쌍욕하다 걸리면 껍데기 벗기겠다”…어느 식당 주인의 경고문, 왜?",
+                    url: "https://www.mk.co.kr/news/society/11060502",
+                  },
+                  {
+                    newsTitle:
+                      "24개 학교서 1000여명 식중독 의심…김치 하나에 난리 난 남원시",
+                    url: "https://www.mk.co.kr/news/society/11060486",
+                  },
+                ],
               },
-              subNews: [
-                {
+              {
+                mediaName: "연합뉴스TV",
+                sourceLogo: "assets/news/logo/yonhap.svg",
+                newsDate: "2023.02.10. 18:27",
+                subscribe: "Y",
+                mainNews: {
+                  thumbnailImage:
+                    "https://img0.yna.co.kr/photo/yna/YH/2024/01/04/PYH2024010414600001300_P4.jpg",
                   newsTitle:
-                    "폭염에 이틀째 정전이라니 어쩌나…410가구 아파트 주민 불편",
-                  url: "https://www.mk.co.kr/news/society/11060544",
+                    '유소년 경기서 욕설·폭언…손웅정측 "답답해 거친 표현"',
+                  url: "https://www.yonhapnewstv.co.kr/news/MYH20240706007700032",
                 },
-                {
-                  newsTitle:
-                    "“차라리 알바를 하고 말지”…9급 공무원 초임 월급보니 ‘충격’",
-                  url: "https://www.mk.co.kr/news/society/11060462",
-                },
-                {
-                  newsTitle:
-                    "“가서 앉아있으면 되나”…현금 5천만원 발견된 아파트 화단서 또 나왔다",
-                  url: "https://www.mk.co.kr/news/society/11060440",
-                },
-                {
-                  newsTitle:
-                    "“몸에서 냄새 나잖아”…직장 동료 세탁기에 강제로 넣고 돌린 日남성",
-                  url: "https://www.mk.co.kr/news/world/11060523",
-                },
-                {
-                  newsTitle:
-                    "“쌍욕하다 걸리면 껍데기 벗기겠다”…어느 식당 주인의 경고문, 왜?",
-                  url: "https://www.mk.co.kr/news/society/11060502",
-                },
-                {
-                  newsTitle:
-                    "24개 학교서 1000여명 식중독 의심…김치 하나에 난리 난 남원시",
-                  url: "https://www.mk.co.kr/news/society/11060486",
-                },
-              ],
-            },
-            {
-              mediaName: "연합뉴스TV",
-              sourceLogo: "assets/news/logo/yonhap.svg",
-              newsDate: "2023.02.10. 18:27",
-              subscribe: "Y",
-              mainNews: {
-                thumbnailImage:
-                  "https://img0.yna.co.kr/photo/yna/YH/2024/01/04/PYH2024010414600001300_P4.jpg",
-                newsTitle:
-                  '유소년 경기서 욕설·폭언…손웅정측 "답답해 거친 표현"',
-                url: "https://www.yonhapnewstv.co.kr/news/MYH20240706007700032",
+                subNews: [
+                  {
+                    newsTitle: "9급 공무원, 월급 최저임금보다 16만원 더 받아",
+                    url: "https://www.yonhapnewstv.co.kr/news/MYH20240706006700641",
+                  },
+                  {
+                    newsTitle: '초저출산 시대 위기 해법은…"사회 개혁 함께해야"',
+                    url: "https://www.yonhapnewstv.co.kr/news/MYH20240706002800641",
+                  },
+                  {
+                    newsTitle:
+                      "코레일 서울본부 전산센터 불…일부 역 발권기 '먹통'",
+                    url: "https://www.yonhapnewstv.co.kr/news/MYH20240706007900641",
+                  },
+                  {
+                    newsTitle: "사건·사고로 얼룩진 美 독립기념일…최소 26명 사망",
+                    url: "https://www.yonhapnewstv.co.kr/news/MYH20240706006000641",
+                  },
+                  {
+                    newsTitle:
+                      "바이든 '설욕전' 조기 성사되나…\"트럼프 제안 수용할 것\"",
+                    url: "https://www.yonhapnewstv.co.kr/news/MYH20240706008300032",
+                  },
+                  {
+                    newsTitle:
+                      "[단독] 온라인수출 1위는 음반 쇼핑몰…K팝이 쿠팡 추월해",
+                    url: "https://www.yonhapnewstv.co.kr/news/MYH20240706000400641",
+                  },
+                ],
               },
-              subNews: [
-                {
-                  newsTitle: "9급 공무원, 월급 최저임금보다 16만원 더 받아",
-                  url: "https://www.yonhapnewstv.co.kr/news/MYH20240706006700641",
+              {
+                mediaName: "세계일보",
+                sourceLogo: "assets/news/logo/segye.svg",
+                newsDate: "2023.02.10. 11:11",
+                subscribe: "Y",
+                mainNews: {
+                  thumbnailImage:
+                    "https://img.segye.com/content/image/2024/07/05/20240705508906.jpg",
+                  newsTitle: "일상화된 ‘저강도 도발’… 북한의 노림수는",
+                  url: "https://www.segye.com/newsView/20240705508875",
                 },
-                {
-                  newsTitle: '초저출산 시대 위기 해법은…"사회 개혁 함께해야"',
-                  url: "https://www.yonhapnewstv.co.kr/news/MYH20240706002800641",
-                },
-                {
-                  newsTitle:
-                    "코레일 서울본부 전산센터 불…일부 역 발권기 '먹통'",
-                  url: "https://www.yonhapnewstv.co.kr/news/MYH20240706007900641",
-                },
-                {
-                  newsTitle: "사건·사고로 얼룩진 美 독립기념일…최소 26명 사망",
-                  url: "https://www.yonhapnewstv.co.kr/news/MYH20240706006000641",
-                },
-                {
-                  newsTitle:
-                    "바이든 '설욕전' 조기 성사되나…\"트럼프 제안 수용할 것\"",
-                  url: "https://www.yonhapnewstv.co.kr/news/MYH20240706008300032",
-                },
-                {
-                  newsTitle:
-                    "[단독] 온라인수출 1위는 음반 쇼핑몰…K팝이 쿠팡 추월해",
-                  url: "https://www.yonhapnewstv.co.kr/news/MYH20240706000400641",
-                },
-              ],
-            },
-            {
-              mediaName: "세계일보",
-              sourceLogo: "assets/news/logo/segye.svg",
-              newsDate: "2023.02.10. 11:11",
-              subscribe: "Y",
-              mainNews: {
-                thumbnailImage:
-                  "https://img.segye.com/content/image/2024/07/05/20240705508906.jpg",
-                newsTitle: "일상화된 ‘저강도 도발’… 북한의 노림수는",
-                url: "https://www.segye.com/newsView/20240705508875",
+                subNews: [
+                  {
+                    newsTitle:
+                      "비가 이어지는 기간?…이젠 장마도 폭염·폭우 공존 ‘양극화’ [날씨+]",
+                    url: "https://www.segye.com/newsView/20240705511450",
+                  },
+                  {
+                    newsTitle:
+                      "민주, 검찰총장에 “허세 그만…김건희 수사나 제대로 하라” 일침",
+                    url: "https://www.segye.com/newsView/20240706504146",
+                  },
+                  {
+                    newsTitle:
+                      "바이든 “나 40살처럼 보이지 않나”…연설서 두 차례나 강조",
+                    url: "https://www.segye.com/newsView/20240706504090",
+                  },
+                  {
+                    newsTitle:
+                      "몸값 높아지는 서울 ‘소형 아파트’…사회초년생 주거 부담 강화 우려도",
+                    url: "https://www.segye.com/newsView/20240705511297",
+                  },
+                  {
+                    newsTitle:
+                      "[내일날씨] 습하고 더운 날씨 지속…충청·남부지방 강한 비",
+                    url: "https://www.segye.com/newsView/20240706504922",
+                  },
+                  {
+                    newsTitle:
+                      "이번엔 서울역서 80대 운전자가…행인 2명 치고, 벽 들이받은 후 멈춰",
+                    url: "https://www.segye.com/newsView/20240706504441",
+                  },
+                ],
               },
-              subNews: [
-                {
+            ],
+          },
+          {
+            tabName: "IT",
+            category: "it",
+            tabData: [
+              {
+                mediaName: "조선일보",
+                sourceLogo: "assets/news/logo/chosun.svg",
+                newsDate: "2023.12.10. 11:27",
+                subscribe: "Y",
+                mainNews: {
+                  thumbnailImage:
+                    "https://imgnews.pstatic.net/image/023/2024/07/06/0003844628_001_20240706160012847.jpg?type=w647",
                   newsTitle:
-                    "비가 이어지는 기간?…이젠 장마도 폭염·폭우 공존 ‘양극화’ [날씨+]",
-                  url: "https://www.segye.com/newsView/20240705511450",
+                    "서울역 인근서 80대 운전자 인도 돌진…시민 2명 차로 치어",
+                  url: "https://n.news.naver.com/article/023/0003844628",
                 },
-                {
-                  newsTitle:
-                    "민주, 검찰총장에 “허세 그만…김건희 수사나 제대로 하라” 일침",
-                  url: "https://www.segye.com/newsView/20240706504146",
-                },
-                {
-                  newsTitle:
-                    "바이든 “나 40살처럼 보이지 않나”…연설서 두 차례나 강조",
-                  url: "https://www.segye.com/newsView/20240706504090",
-                },
-                {
-                  newsTitle:
-                    "몸값 높아지는 서울 ‘소형 아파트’…사회초년생 주거 부담 강화 우려도",
-                  url: "https://www.segye.com/newsView/20240705511297",
-                },
-                {
-                  newsTitle:
-                    "[내일날씨] 습하고 더운 날씨 지속…충청·남부지방 강한 비",
-                  url: "https://www.segye.com/newsView/20240706504922",
-                },
-                {
-                  newsTitle:
-                    "이번엔 서울역서 80대 운전자가…행인 2명 치고, 벽 들이받은 후 멈춰",
-                  url: "https://www.segye.com/newsView/20240706504441",
-                },
-              ],
-            },
-          ],
-        },
-        {
-          tabName: "IT",
-          category: "it",
-          tabData: [
-            {
-              mediaName: "조선일보",
-              sourceLogo: "assets/news/logo/chosun.svg",
-              newsDate: "2023.12.10. 11:27",
-              subscribe: "Y",
-              mainNews: {
-                thumbnailImage:
-                  "https://imgnews.pstatic.net/image/023/2024/07/06/0003844628_001_20240706160012847.jpg?type=w647",
-                newsTitle:
-                  "서울역 인근서 80대 운전자 인도 돌진…시민 2명 차로 치어",
-                url: "https://n.news.naver.com/article/023/0003844628",
+                subNews: [
+                  {
+                    newsTitle:
+                      "“머스크 형님, 믿습니다. 테멘”...테슬라 주가, 올해 처음으로 수익률 플러스 전환",
+                    url: "https://n.news.naver.com/article/023/0003844603",
+                  },
+                  {
+                    newsTitle:
+                      "이영지, 가정사 고백...”집 나간 아버지, 이젠 모르는 아저씨”",
+                    url: "https://n.news.naver.com/article/023/0003844612",
+                  },
+                  {
+                    newsTitle:
+                      "붉은 피로 물든 바다…해변서 놀던 美 여성, 상어에게 물렸다",
+                    url: "https://n.news.naver.com/article/023/0003844602",
+                  },
+                  {
+                    newsTitle:
+                      "이들의 잘못된 만남…좋아하는 사람 만났다고 친구 폭행·감금한 20대",
+                    url: "https://n.news.naver.com/article/023/0003844636",
+                  },
+                  {
+                    newsTitle:
+                      "‘갑질 의혹’ 강형욱, 사실상 본업 복귀…반려견 교육 유튜브 재개",
+                    url: "https://n.news.naver.com/article/023/0003844635",
+                  },
+                  {
+                    newsTitle: "日 지하철 탔다가 나비 크기에 식겁...어떻길래",
+                    url: "https://n.news.naver.com/article/023/0003844627",
+                  },
+                ],
               },
-              subNews: [
-                {
+              {
+                mediaName: "동아일보",
+                sourceLogo: "assets/news/logo/donga.svg",
+                newsDate: "2023.03.13. 18:27",
+                subscribe: "N",
+                mainNews: {
+                  thumbnailImage:
+                    "https://imgnews.pstatic.net/image/020/2024/07/06/0003574812_001_20240706150510496.jpg",
                   newsTitle:
-                    "“머스크 형님, 믿습니다. 테멘”...테슬라 주가, 올해 처음으로 수익률 플러스 전환",
-                  url: "https://n.news.naver.com/article/023/0003844603",
+                    "‘시청역 역주행 사고’ 가해차량, 최근 6년간 6번 사고 이력",
+                  url: "https://n.news.naver.com/article/020/0003574812",
                 },
-                {
-                  newsTitle:
-                    "이영지, 가정사 고백...”집 나간 아버지, 이젠 모르는 아저씨”",
-                  url: "https://n.news.naver.com/article/023/0003844612",
-                },
-                {
-                  newsTitle:
-                    "붉은 피로 물든 바다…해변서 놀던 美 여성, 상어에게 물렸다",
-                  url: "https://n.news.naver.com/article/023/0003844602",
-                },
-                {
-                  newsTitle:
-                    "이들의 잘못된 만남…좋아하는 사람 만났다고 친구 폭행·감금한 20대",
-                  url: "https://n.news.naver.com/article/023/0003844636",
-                },
-                {
-                  newsTitle:
-                    "‘갑질 의혹’ 강형욱, 사실상 본업 복귀…반려견 교육 유튜브 재개",
-                  url: "https://n.news.naver.com/article/023/0003844635",
-                },
-                {
-                  newsTitle: "日 지하철 탔다가 나비 크기에 식겁...어떻길래",
-                  url: "https://n.news.naver.com/article/023/0003844627",
-                },
-              ],
-            },
-            {
-              mediaName: "동아일보",
-              sourceLogo: "assets/news/logo/donga.svg",
-              newsDate: "2023.03.13. 18:27",
-              subscribe: "N",
-              mainNews: {
-                thumbnailImage:
-                  "https://imgnews.pstatic.net/image/020/2024/07/06/0003574812_001_20240706150510496.jpg",
-                newsTitle:
-                  "‘시청역 역주행 사고’ 가해차량, 최근 6년간 6번 사고 이력",
-                url: "https://n.news.naver.com/article/020/0003574812",
+                subNews: [
+                  {
+                    newsTitle:
+                      "줄서도 못사는 두바이초콜릿 먹어보니… “왜 인기인지 알겠다”",
+                    url: "https://n.news.naver.com/article/020/0003574796",
+                  },
+                  {
+                    newsTitle:
+                      "“사이판 수영장서 1초만에 전신마비”…무사 귀국한 유튜버의 뒷 이야기",
+                    url: "https://n.news.naver.com/article/020/0003574811",
+                  },
+                  {
+                    newsTitle:
+                      "“이 길을 어떻게 오르라고” 상명대 ‘지옥의 오르막’ 버스 중단 고심",
+                    url: "https://n.news.naver.com/article/020/0003574793",
+                  },
+                  {
+                    newsTitle:
+                      "점당 200원 ‘고스톱’ 쳤다가 법정 선 70대 노인들…법원 “심심풀이·치매예방”",
+                    url: "https://n.news.naver.com/article/020/0003574801",
+                  },
+                  {
+                    newsTitle:
+                      "“얼마나 피로했을까”…시청역 앞 놓인 ‘숙취해소제’에 울컥",
+                    url: "https://n.news.naver.com/article/020/0003574658",
+                  },
+                  {
+                    newsTitle:
+                      "“손흥민 떴다!” 동네 축구장에 깜짝등장…순식간 2000명 몰려 경찰투입",
+                    url: "https://n.news.naver.com/article/020/0003574795",
+                  },
+                ],
               },
-              subNews: [
-                {
+            ],
+          },
+          {
+            tabName: "영자지",
+            category: "entertainment",
+            tabData: [
+              {
+                mediaName: "서울신문",
+                sourceLogo: "assets/news/logo/seoul.svg",
+                newsDate: "2023.04.15. 18:27",
+                subscribe: "Y",
+                mainNews: {
+                  thumbnailImage:
+                    "https://imgnews.pstatic.net/image/081/2024/07/06/0003462874_001_20240706213311195.jpg",
                   newsTitle:
-                    "줄서도 못사는 두바이초콜릿 먹어보니… “왜 인기인지 알겠다”",
-                  url: "https://n.news.naver.com/article/020/0003574796",
+                    "“도대체 당신 누구야”…유명 식당 여주인은 그놈에게 끝내 ‘청부살해’ 당했다[전국부 사건창고]",
+                  url: "https://n.news.naver.com/article/081/0003462874",
                 },
-                {
-                  newsTitle:
-                    "“사이판 수영장서 1초만에 전신마비”…무사 귀국한 유튜버의 뒷 이야기",
-                  url: "https://n.news.naver.com/article/020/0003574811",
-                },
-                {
-                  newsTitle:
-                    "“이 길을 어떻게 오르라고” 상명대 ‘지옥의 오르막’ 버스 중단 고심",
-                  url: "https://n.news.naver.com/article/020/0003574793",
-                },
-                {
-                  newsTitle:
-                    "점당 200원 ‘고스톱’ 쳤다가 법정 선 70대 노인들…법원 “심심풀이·치매예방”",
-                  url: "https://n.news.naver.com/article/020/0003574801",
-                },
-                {
-                  newsTitle:
-                    "“얼마나 피로했을까”…시청역 앞 놓인 ‘숙취해소제’에 울컥",
-                  url: "https://n.news.naver.com/article/020/0003574658",
-                },
-                {
-                  newsTitle:
-                    "“손흥민 떴다!” 동네 축구장에 깜짝등장…순식간 2000명 몰려 경찰투입",
-                  url: "https://n.news.naver.com/article/020/0003574795",
-                },
-              ],
-            },
-          ],
-        },
-        {
-          tabName: "영자지",
-          category: "entertainment",
-          tabData: [
-            {
-              mediaName: "서울신문",
-              sourceLogo: "assets/news/logo/seoul.svg",
-              newsDate: "2023.04.15. 18:27",
-              subscribe: "Y",
-              mainNews: {
-                thumbnailImage:
-                  "https://imgnews.pstatic.net/image/081/2024/07/06/0003462874_001_20240706213311195.jpg",
-                newsTitle:
-                  "“도대체 당신 누구야”…유명 식당 여주인은 그놈에게 끝내 ‘청부살해’ 당했다[전국부 사건창고]",
-                url: "https://n.news.naver.com/article/081/0003462874",
+                subNews: [
+                  {
+                    newsTitle:
+                      "“내가 좋아하는 女 만나?”…친구 4시간 감금·폭행한 20대들",
+                    url: "https://n.news.naver.com/article/081/0003462892",
+                  },
+                  {
+                    newsTitle:
+                      "대낮 길거리서 60대母 둔기로 폭행한 30대 아들 체포",
+                    url: "https://n.news.naver.com/article/081/0003462895",
+                  },
+                  {
+                    newsTitle:
+                      "한동훈, 김건희 문자 ‘읽씹’ 논란 “사적대화 부적절”…나경원 “구차 변명”",
+                    url: "https://n.news.naver.com/article/081/0003462886",
+                  },
+                  {
+                    newsTitle:
+                      "“소변색이 왜이래” 운동 열심히 했는데…갑자기 ‘콜라색’ 된 이유",
+                    url: "https://n.news.naver.com/article/081/0003462884",
+                  },
+                  {
+                    newsTitle:
+                      "“노인네들 운전대 잡지마라”…시청역 사고 후 ‘노인 비하’ 도 넘었다",
+                    url: "https://n.news.naver.com/article/081/0003462880",
+                  },
+                  {
+                    newsTitle:
+                      "진성준 “어디다 대고” 배현진 “뭐 뭐 쳐봐”…몸싸움 직전 일촉즉발",
+                    url: "https://n.news.naver.com/article/081/0003462879",
+                  },
+                ],
               },
-              subNews: [
-                {
+              {
+                mediaName: "한겨레",
+                sourceLogo: "assets/news/logo/hankyoreh.svg",
+                newsDate: "2024.04.10. 18:27",
+                subscribe: "Y",
+                mainNews: {
+                  thumbnailImage:
+                    "https://imgnews.pstatic.net/image/028/2024/07/05/0002696883_001_20240706181017816.jpg",
                   newsTitle:
-                    "“내가 좋아하는 女 만나?”…친구 4시간 감금·폭행한 20대들",
-                  url: "https://n.news.naver.com/article/081/0003462892",
+                    "‘김건희’ 전면 등장 이상한 전당대회…한동훈과 진실 공방 번지나",
+                  url: "https://n.news.naver.com/article/028/0002696883",
                 },
-                {
-                  newsTitle:
-                    "대낮 길거리서 60대母 둔기로 폭행한 30대 아들 체포",
-                  url: "https://n.news.naver.com/article/081/0003462895",
-                },
-                {
-                  newsTitle:
-                    "한동훈, 김건희 문자 ‘읽씹’ 논란 “사적대화 부적절”…나경원 “구차 변명”",
-                  url: "https://n.news.naver.com/article/081/0003462886",
-                },
-                {
-                  newsTitle:
-                    "“소변색이 왜이래” 운동 열심히 했는데…갑자기 ‘콜라색’ 된 이유",
-                  url: "https://n.news.naver.com/article/081/0003462884",
-                },
-                {
-                  newsTitle:
-                    "“노인네들 운전대 잡지마라”…시청역 사고 후 ‘노인 비하’ 도 넘었다",
-                  url: "https://n.news.naver.com/article/081/0003462880",
-                },
-                {
-                  newsTitle:
-                    "진성준 “어디다 대고” 배현진 “뭐 뭐 쳐봐”…몸싸움 직전 일촉즉발",
-                  url: "https://n.news.naver.com/article/081/0003462879",
-                },
-              ],
-            },
-            {
-              mediaName: "한겨레",
-              sourceLogo: "assets/news/logo/hankyoreh.svg",
-              newsDate: "2024.04.10. 18:27",
-              subscribe: "Y",
-              mainNews: {
-                thumbnailImage:
-                  "https://imgnews.pstatic.net/image/028/2024/07/05/0002696883_001_20240706181017816.jpg",
-                newsTitle:
-                  "‘김건희’ 전면 등장 이상한 전당대회…한동훈과 진실 공방 번지나",
-                url: "https://n.news.naver.com/article/028/0002696883",
+                subNews: [
+                  {
+                    newsTitle:
+                      "백화점이 돈 풀자 이불집·반찬집·정육점 사장님 줄줄이 검찰청으로",
+                    url: "https://n.news.naver.com/article/028/0002696917",
+                  },
+                  {
+                    newsTitle:
+                      "‘페미 집게손가락’ 망상…이번에도 받아 준 기업 잘못이다",
+                    url: "https://n.news.naver.com/article/028/0002696896",
+                  },
+                  {
+                    newsTitle:
+                      "임성근 빠진 경찰 수사심의…“시간 끌더니 대통령 입맛대로”",
+                    url: "https://n.news.naver.com/article/028/0002696925",
+                  },
+                  {
+                    newsTitle:
+                      "코레일 서울본부 전산실 화재…전국 대부분 역 현장발권 차질",
+                    url: "https://n.news.naver.com/article/028/0002696921",
+                  },
+                  {
+                    newsTitle:
+                      "백화점이 돈 풀자 이불집·반찬집·정육점 사장님 줄줄이 검찰청으로",
+                    url: "https://n.news.naver.com/article/028/0002696917",
+                  },
+                  {
+                    newsTitle:
+                      "서방 관계 개선·히잡 완화 공약…이란 대선, 개혁파 후보 당선",
+                    url: "https://n.news.naver.com/article/028/0002696924",
+                  },
+                ],
               },
-              subNews: [
-                {
+            ],
+          },
+          {
+            tabName: "스포츠/연예",
+            category: "sports",
+            tabData: [
+              {
+                mediaName: "문화일보",
+                sourceLogo: "assets/news/logo/munhwa.svg",
+                newsDate: "2023.09.10. 18:27",
+                subscribe: "N",
+                mainNews: {
+                  thumbnailImage:
+                    "https://imgnews.pstatic.net/image/021/2024/07/06/0002647014_001_20240706141911138.jpg",
                   newsTitle:
-                    "백화점이 돈 풀자 이불집·반찬집·정육점 사장님 줄줄이 검찰청으로",
-                  url: "https://n.news.naver.com/article/028/0002696917",
+                    "“푸틴, 김정은에 우크라 파병 요구… 김정은 확답 안 해”",
+                  url: "https://n.news.naver.com/article/021/0002647014",
                 },
-                {
-                  newsTitle:
-                    "‘페미 집게손가락’ 망상…이번에도 받아 준 기업 잘못이다",
-                  url: "https://n.news.naver.com/article/028/0002696896",
-                },
-                {
-                  newsTitle:
-                    "임성근 빠진 경찰 수사심의…“시간 끌더니 대통령 입맛대로”",
-                  url: "https://n.news.naver.com/article/028/0002696925",
-                },
-                {
-                  newsTitle:
-                    "코레일 서울본부 전산실 화재…전국 대부분 역 현장발권 차질",
-                  url: "https://n.news.naver.com/article/028/0002696921",
-                },
-                {
-                  newsTitle:
-                    "백화점이 돈 풀자 이불집·반찬집·정육점 사장님 줄줄이 검찰청으로",
-                  url: "https://n.news.naver.com/article/028/0002696917",
-                },
-                {
-                  newsTitle:
-                    "서방 관계 개선·히잡 완화 공약…이란 대선, 개혁파 후보 당선",
-                  url: "https://n.news.naver.com/article/028/0002696924",
-                },
-              ],
-            },
-          ],
-        },
-        {
-          tabName: "스포츠/연예",
-          category: "sports",
-          tabData: [
-            {
-              mediaName: "문화일보",
-              sourceLogo: "assets/news/logo/munhwa.svg",
-              newsDate: "2023.09.10. 18:27",
-              subscribe: "N",
-              mainNews: {
-                thumbnailImage:
-                  "https://imgnews.pstatic.net/image/021/2024/07/06/0002647014_001_20240706141911138.jpg",
-                newsTitle:
-                  "“푸틴, 김정은에 우크라 파병 요구… 김정은 확답 안 해”",
-                url: "https://n.news.naver.com/article/021/0002647014",
+                subNews: [
+                  {
+                    newsTitle:
+                      "서울역 인근서 80대 운전 차량 인도 행인 2명 잇따라 치어",
+                    url: "https://n.news.naver.com/article/021/0002647025",
+                  },
+                  {
+                    newsTitle:
+                      "80대 환자에 급히 죽 떠먹여 질식사시킨 요양보호사…2심도 유죄",
+                    url: "https://n.news.naver.com/article/021/0002647026",
+                  },
+                  {
+                    newsTitle: "‘네카오’ 시총 올해 15조 증발…외국인 보유율 감소",
+                    url: "https://n.news.naver.com/article/021/0002647000",
+                  },
+                  {
+                    newsTitle: "주유소 기름값 2주 연속 상승…전국 평균 ‘1682.2원’",
+                    url: "https://n.news.naver.com/article/021/0002646994",
+                  },
+                  {
+                    newsTitle:
+                      "“재료값 내려갔다고 삼계탕 가격이 싸질까요?” 아니예요",
+                    url: "https://n.news.naver.com/article/021/0002646981",
+                  },
+                  {
+                    newsTitle:
+                      "‘9만전자 눈 앞’…삼성전자 3% 급등해 3년5개월만에 최고치",
+                    url: "https://n.news.naver.com/article/021/0002646958",
+                  },
+                ],
               },
-              subNews: [
-                {
-                  newsTitle:
-                    "서울역 인근서 80대 운전 차량 인도 행인 2명 잇따라 치어",
-                  url: "https://n.news.naver.com/article/021/0002647025",
+              {
+                mediaName: "국민일보",
+                sourceLogo: "assets/news/logo/kookmin.svg",
+                newsDate: "2024.10.30. 18:27",
+                subscribe: "Y",
+                mainNews: {
+                  thumbnailImage:
+                    "https://imgnews.pstatic.net/image/005/2024/07/06/2024070605322412876_1720211544_0020279245_20240706064407477.jpg",
+                  newsTitle: "이전 ‘급발진 주장’ 블랙박스 보니…“가속페달만 6번”",
+                  url: "https://n.news.naver.com/article/005/0001708786",
                 },
-                {
-                  newsTitle:
-                    "80대 환자에 급히 죽 떠먹여 질식사시킨 요양보호사…2심도 유죄",
-                  url: "https://n.news.naver.com/article/021/0002647026",
-                },
-                {
-                  newsTitle: "‘네카오’ 시총 올해 15조 증발…외국인 보유율 감소",
-                  url: "https://n.news.naver.com/article/021/0002647000",
-                },
-                {
-                  newsTitle: "주유소 기름값 2주 연속 상승…전국 평균 ‘1682.2원’",
-                  url: "https://n.news.naver.com/article/021/0002646994",
-                },
-                {
-                  newsTitle:
-                    "“재료값 내려갔다고 삼계탕 가격이 싸질까요?” 아니예요",
-                  url: "https://n.news.naver.com/article/021/0002646981",
-                },
-                {
-                  newsTitle:
-                    "‘9만전자 눈 앞’…삼성전자 3% 급등해 3년5개월만에 최고치",
-                  url: "https://n.news.naver.com/article/021/0002646958",
-                },
-              ],
-            },
-            {
-              mediaName: "국민일보",
-              sourceLogo: "assets/news/logo/kookmin.svg",
-              newsDate: "2024.10.30. 18:27",
-              subscribe: "Y",
-              mainNews: {
-                thumbnailImage:
-                  "https://imgnews.pstatic.net/image/005/2024/07/06/2024070605322412876_1720211544_0020279245_20240706064407477.jpg",
-                newsTitle: "이전 ‘급발진 주장’ 블랙박스 보니…“가속페달만 6번”",
-                url: "https://n.news.naver.com/article/005/0001708786",
+                subNews: [
+                  {
+                    newsTitle:
+                      "남원 학교 식중독 의심환자 1000명 넘어… 사흘 만에 800명 급증",
+                    url: "https://n.news.naver.com/article/005/0001708803",
+                  },
+                  {
+                    newsTitle:
+                      "한동훈, 원희룡 당 선관위 신고 “인신공격성 문자 보내”",
+                    url: "https://n.news.naver.com/article/005/0001708806",
+                  },
+                  {
+                    newsTitle:
+                      "이번엔 서울역 인근서… 80대 운전자 차량 인도 덮쳐\n",
+                    url: "https://n.news.naver.com/article/005/0001708807",
+                  },
+                  {
+                    newsTitle: "바이든 “내가 트럼프 이길 것”…신체검사는 ‘거부’",
+                    url: "https://n.news.naver.com/article/005/0001708800",
+                  },
+                  {
+                    newsTitle:
+                      "“손흥민, 용인 조축 떴다” 2천명 몰려 난리…경찰 출동",
+                    url: "https://n.news.naver.com/article/005/0001708792",
+                  },
+                  {
+                    newsTitle:
+                      "‘채상병 사건’ 경찰 심의위 “임성근 전 사단장 불송치”",
+                    url: "https://n.news.naver.com/article/005/0001708796",
+                  },
+                ],
               },
-              subNews: [
-                {
+            ],
+          },
+          {
+            tabName: "매거진/전문지",
+            category: "magazine",
+            tabData: [
+              {
+                mediaName: "데일리안",
+                sourceLogo: "assets/news/logo/dailyan.svg",
+                newsDate: "2022.02.22. 18:27",
+                subscribe: "Y",
+                mainNews: {
+                  thumbnailImage:
+                    "https://cdnimage.dailian.co.kr/news/202407/news_1720067848_1379800_m_1.jpeg",
                   newsTitle:
-                    "남원 학교 식중독 의심환자 1000명 넘어… 사흘 만에 800명 급증",
-                  url: "https://n.news.naver.com/article/005/0001708803",
+                    "화성시, 1조원 규모ASML-삼성전자 연구지원시설 투자유치 성공",
+                  url: "https://www.dailian.co.kr/news/view/1379800/",
                 },
-                {
-                  newsTitle:
-                    "한동훈, 원희룡 당 선관위 신고 “인신공격성 문자 보내”",
-                  url: "https://n.news.naver.com/article/005/0001708806",
-                },
-                {
-                  newsTitle:
-                    "이번엔 서울역 인근서… 80대 운전자 차량 인도 덮쳐\n",
-                  url: "https://n.news.naver.com/article/005/0001708807",
-                },
-                {
-                  newsTitle: "바이든 “내가 트럼프 이길 것”…신체검사는 ‘거부’",
-                  url: "https://n.news.naver.com/article/005/0001708800",
-                },
-                {
-                  newsTitle:
-                    "“손흥민, 용인 조축 떴다” 2천명 몰려 난리…경찰 출동",
-                  url: "https://n.news.naver.com/article/005/0001708792",
-                },
-                {
-                  newsTitle:
-                    "‘채상병 사건’ 경찰 심의위 “임성근 전 사단장 불송치”",
-                  url: "https://n.news.naver.com/article/005/0001708796",
-                },
-              ],
-            },
-          ],
-        },
-        {
-          tabName: "매거진/전문지",
-          category: "magazine",
-          tabData: [
-            {
-              mediaName: "데일리안",
-              sourceLogo: "assets/news/logo/dailyan.svg",
-              newsDate: "2022.02.22. 18:27",
-              subscribe: "Y",
-              mainNews: {
-                thumbnailImage:
-                  "https://cdnimage.dailian.co.kr/news/202407/news_1720067848_1379800_m_1.jpeg",
-                newsTitle:
-                  "화성시, 1조원 규모ASML-삼성전자 연구지원시설 투자유치 성공",
-                url: "https://www.dailian.co.kr/news/view/1379800/",
+                subNews: [
+                  {
+                    newsTitle: '크래프톤 "카카오게임즈 인수 검토 사실무근"',
+                    url: "https://www.dailian.co.kr/news/view/1380387/",
+                  },
+                  {
+                    newsTitle:
+                      "[단독] \"안철수 제명하라\"...'채상병 특검법' 찬성에 與 내부 '부글부글'",
+                    url: "https://www.dailian.co.kr/news/view/1380193/",
+                  },
+                  {
+                    newsTitle:
+                      "아버지도 버린 노소영의 '1조3808억', 노태우 회고록엔… [데스크 칼럼]",
+                    url: "https://www.dailian.co.kr/news/view/1380187/",
+                  },
+                  {
+                    newsTitle: "안산 학원 화장실서 여고생 찌른 남학생 결국 사망",
+                    url: "https://www.dailian.co.kr/news/view/1380218/",
+                  },
+                  {
+                    newsTitle:
+                      "한동훈이 던진 '채상병 특검 수정안'…당심 움직일 카드될까 [정국 기상대]",
+                    url: "https://www.dailian.co.kr/news/view/1379985/",
+                  },
+                  {
+                    newsTitle:
+                      "사고만 나면 급발진?…가속페달 7번 밟고 '급발진 주장' 사례도",
+                    url: "https://www.dailian.co.kr/news/view/1380221/",
+                  },
+                ],
               },
-              subNews: [
-                {
-                  newsTitle: '크래프톤 "카카오게임즈 인수 검토 사실무근"',
-                  url: "https://www.dailian.co.kr/news/view/1380387/",
-                },
-                {
+              {
+                mediaName: "아이뉴스",
+                sourceLogo: "assets/news/logo/inews.svg",
+                newsDate: "2021.01.11. 11:07",
+                subscribe: "Y",
+                mainNews: {
+                  thumbnailImage:
+                    "https://image.inews24.com/v1/d78daaadfcbb27.jpg",
                   newsTitle:
-                    "[단독] \"안철수 제명하라\"...'채상병 특검법' 찬성에 與 내부 '부글부글'",
-                  url: "https://www.dailian.co.kr/news/view/1380193/",
+                    "'히잡 단속 완화' 개혁파 페제시키안 이란 대통령 당선",
+                  url: "https://www.inews24.com/view/1738954",
                 },
-                {
-                  newsTitle:
-                    "아버지도 버린 노소영의 '1조3808억', 노태우 회고록엔… [데스크 칼럼]",
-                  url: "https://www.dailian.co.kr/news/view/1380187/",
-                },
-                {
-                  newsTitle: "안산 학원 화장실서 여고생 찌른 남학생 결국 사망",
-                  url: "https://www.dailian.co.kr/news/view/1380218/",
-                },
-                {
-                  newsTitle:
-                    "한동훈이 던진 '채상병 특검 수정안'…당심 움직일 카드될까 [정국 기상대]",
-                  url: "https://www.dailian.co.kr/news/view/1379985/",
-                },
-                {
-                  newsTitle:
-                    "사고만 나면 급발진?…가속페달 7번 밟고 '급발진 주장' 사례도",
-                  url: "https://www.dailian.co.kr/news/view/1380221/",
-                },
-              ],
-            },
-            {
-              mediaName: "아이뉴스",
-              sourceLogo: "assets/news/logo/inews.svg",
-              newsDate: "2021.01.11. 11:07",
-              subscribe: "Y",
-              mainNews: {
-                thumbnailImage:
-                  "https://image.inews24.com/v1/d78daaadfcbb27.jpg",
-                newsTitle:
-                  "'히잡 단속 완화' 개혁파 페제시키안 이란 대통령 당선",
-                url: "https://www.inews24.com/view/1738954",
+                subNews: [
+                  {
+                    newsTitle: '"기름 넣기 무섭네"… 주유소 기름값 2주째 상승',
+                    url: "https://www.inews24.com/view/1738957",
+                  },
+                  {
+                    newsTitle:
+                      "22대 국회 초유의 극한 대립…'협치' 열쇠는 尹 손에 [여의뷰]",
+                    url: "https://www.inews24.com/view/1738873",
+                  },
+                  {
+                    newsTitle:
+                      "'교섭단체 요건 완화' 목소리 키우지만…등 돌린 '국힘·민주'",
+                    url: "https://www.inews24.com/view/1738883",
+                  },
+                  {
+                    newsTitle: "尹, 3년 연속 나토정상회의 참석…다음주 방미",
+                    url: "https://www.inews24.com/view/1738847",
+                  },
+                  {
+                    newsTitle:
+                      "검찰총장, '검사 탄핵' 위법성 검토에…민주당 \"내란행위\"",
+                    url: "https://www.inews24.com/view/1738740",
+                  },
+                  {
+                    newsTitle:
+                      "반지하주택 문제 어떻게 할 것인가?…경기도, 12일 국회서 토론회",
+                    url: "https://www.inews24.com/view/1738542",
+                  },
+                ],
               },
-              subNews: [
-                {
-                  newsTitle: '"기름 넣기 무섭네"… 주유소 기름값 2주째 상승',
-                  url: "https://www.inews24.com/view/1738957",
+            ],
+          },
+          {
+            tabName: "지역",
+            category: "region",
+            tabData: [
+              {
+                mediaName: "MBN",
+                sourceLogo: "assets/news/logo/mbn.svg",
+                newsDate: "2026.06.16. 18:27",
+                subscribe: "N",
+                mainNews: {
+                  thumbnailImage:
+                    "https://img.mbn.co.kr/filewww/news/2024/07/06/17202538806688fdb82f103.jpg",
+                  newsTitle: "'한국은 없네'…가장 이민가고 싶은 나라 1위는?",
+                  url: "https://www.mbn.co.kr/news/world/5039680",
                 },
-                {
-                  newsTitle:
-                    "22대 국회 초유의 극한 대립…'협치' 열쇠는 尹 손에 [여의뷰]",
-                  url: "https://www.inews24.com/view/1738873",
-                },
-                {
-                  newsTitle:
-                    "'교섭단체 요건 완화' 목소리 키우지만…등 돌린 '국힘·민주'",
-                  url: "https://www.inews24.com/view/1738883",
-                },
-                {
-                  newsTitle: "尹, 3년 연속 나토정상회의 참석…다음주 방미",
-                  url: "https://www.inews24.com/view/1738847",
-                },
-                {
-                  newsTitle:
-                    "검찰총장, '검사 탄핵' 위법성 검토에…민주당 \"내란행위\"",
-                  url: "https://www.inews24.com/view/1738740",
-                },
-                {
-                  newsTitle:
-                    "반지하주택 문제 어떻게 할 것인가?…경기도, 12일 국회서 토론회",
-                  url: "https://www.inews24.com/view/1738542",
-                },
-              ],
-            },
-          ],
-        },
-        {
-          tabName: "지역",
-          category: "region",
-          tabData: [
-            {
-              mediaName: "MBN",
-              sourceLogo: "assets/news/logo/mbn.svg",
-              newsDate: "2026.06.16. 18:27",
-              subscribe: "N",
-              mainNews: {
-                thumbnailImage:
-                  "https://img.mbn.co.kr/filewww/news/2024/07/06/17202538806688fdb82f103.jpg",
-                newsTitle: "'한국은 없네'…가장 이민가고 싶은 나라 1위는?",
-                url: "https://www.mbn.co.kr/news/world/5039680",
+                subNews: [
+                  {
+                    newsTitle:
+                      '한동훈 "김 여사 문자 논란, 전당대회 개입이자 당무 개입"',
+                    url: "https://www.mbn.co.kr/news/politics/5039698",
+                  },
+                  {
+                    newsTitle: "[날씨] 주말, 다시 전국 비…폭염특보 확대·강화",
+                    url: "https://mbn.co.kr/news/life/5039578",
+                  },
+                  {
+                    newsTitle:
+                      "조정훈-장경태-천하람이 본 '한동훈-김건희 문자 논란'",
+                    url: "https://www.mbn.co.kr/news/society/5039575",
+                  },
+                  {
+                    newsTitle:
+                      "한동훈 '배신자론'…김건희 여사 문자 무시 때문이었나?",
+                    url: "https://www.mbn.co.kr/news/society/5039574",
+                  },
+                  {
+                    newsTitle: "이란 대통령에 개혁파 페제시키안 당선…55% 득표",
+                    url: "https://www.mbn.co.kr/news/world/5039703",
+                  },
+                  {
+                    newsTitle:
+                      '바이든 "사퇴 없다. 인지력 검사 필요 없어" 정면 돌파',
+                    url: "https://www.mbn.co.kr/news/world/5039696",
+                  },
+                ],
               },
-              subNews: [
-                {
+              {
+                mediaName: "아시아경제",
+                sourceLogo: "assets/news/logo/asia.svg",
+                newsDate: "2020.02.20. 18:27",
+                subscribe: "Y",
+                mainNews: {
+                  thumbnailImage:
+                    "https://cphoto.asiae.co.kr/listimglink/1/2024070617161542351_1720253775.jpg",
                   newsTitle:
-                    '한동훈 "김 여사 문자 논란, 전당대회 개입이자 당무 개입"',
-                  url: "https://www.mbn.co.kr/news/politics/5039698",
+                    "\"최저임금 수준에 청년공무원 떠나\"…공무원노조 '임금인상' 집회",
+                  url: "https://www.asiae.co.kr/article/2024070617173383186",
                 },
-                {
-                  newsTitle: "[날씨] 주말, 다시 전국 비…폭염특보 확대·강화",
-                  url: "https://mbn.co.kr/news/life/5039578",
-                },
-                {
-                  newsTitle:
-                    "조정훈-장경태-천하람이 본 '한동훈-김건희 문자 논란'",
-                  url: "https://www.mbn.co.kr/news/society/5039575",
-                },
-                {
-                  newsTitle:
-                    "한동훈 '배신자론'…김건희 여사 문자 무시 때문이었나?",
-                  url: "https://www.mbn.co.kr/news/society/5039574",
-                },
-                {
-                  newsTitle: "이란 대통령에 개혁파 페제시키안 당선…55% 득표",
-                  url: "https://www.mbn.co.kr/news/world/5039703",
-                },
-                {
-                  newsTitle:
-                    '바이든 "사퇴 없다. 인지력 검사 필요 없어" 정면 돌파',
-                  url: "https://www.mbn.co.kr/news/world/5039696",
-                },
-              ],
-            },
-            {
-              mediaName: "아시아경제",
-              sourceLogo: "assets/news/logo/asia.svg",
-              newsDate: "2020.02.20. 18:27",
-              subscribe: "Y",
-              mainNews: {
-                thumbnailImage:
-                  "https://cphoto.asiae.co.kr/listimglink/1/2024070617161542351_1720253775.jpg",
-                newsTitle:
-                  "\"최저임금 수준에 청년공무원 떠나\"…공무원노조 '임금인상' 집회",
-                url: "https://www.asiae.co.kr/article/2024070617173383186",
+                subNews: [
+                  {
+                    newsTitle: "AB형·O형 부부서 O형 아이 나오자 난리난 집안",
+                    url: "https://www.asiae.co.kr/article/2024070509485160391",
+                  },
+                  {
+                    newsTitle:
+                      '"내가 누군지 알아?"…지각해 비행기 못타자 난동피운 정치인',
+                    url: "https://www.asiae.co.kr/article/2024070508173074446",
+                  },
+                  {
+                    newsTitle:
+                      "주차비 아까워 앞차 꽁무니 '바짝'…3억 벤틀리의 꼼수",
+                    url: "https://www.asiae.co.kr/article/2024070514003800977",
+                  },
+                  {
+                    newsTitle:
+                      '"냄새난다"며 지적장애 동료 세탁기에 넣어…"정신나갔다" 日 공분',
+                    url: "https://www.asiae.co.kr/article/2024070509362498806",
+                  },
+                  {
+                    newsTitle:
+                      '"개 찾아주고 한달 500만원 이상 법니다"…중국서 뜨는 직업',
+                    url: "https://www.asiae.co.kr/article/2024070510191072960",
+                  },
+                  {
+                    newsTitle:
+                      "연일 사상최고치 인도증시…월가 “고점 멀었다” 하는 이유",
+                    url: "https://www.asiae.co.kr/article/world-economy/2024070510185366615",
+                  },
+                ],
               },
-              subNews: [
-                {
-                  newsTitle: "AB형·O형 부부서 O형 아이 나오자 난리난 집안",
-                  url: "https://www.asiae.co.kr/article/2024070509485160391",
-                },
-                {
-                  newsTitle:
-                    '"내가 누군지 알아?"…지각해 비행기 못타자 난동피운 정치인',
-                  url: "https://www.asiae.co.kr/article/2024070508173074446",
-                },
-                {
-                  newsTitle:
-                    "주차비 아까워 앞차 꽁무니 '바짝'…3억 벤틀리의 꼼수",
-                  url: "https://www.asiae.co.kr/article/2024070514003800977",
-                },
-                {
-                  newsTitle:
-                    '"냄새난다"며 지적장애 동료 세탁기에 넣어…"정신나갔다" 日 공분',
-                  url: "https://www.asiae.co.kr/article/2024070509362498806",
-                },
-                {
-                  newsTitle:
-                    '"개 찾아주고 한달 500만원 이상 법니다"…중국서 뜨는 직업',
-                  url: "https://www.asiae.co.kr/article/2024070510191072960",
-                },
-                {
-                  newsTitle:
-                    "연일 사상최고치 인도증시…월가 “고점 멀었다” 하는 이유",
-                  url: "https://www.asiae.co.kr/article/world-economy/2024070510185366615",
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    },
-  ],
-};
+            ],
+          },
+        ],
+      },
+    ],
+  };
 
-export default TAB_NEWS_DATA;
+  export default TAB_NEWS_DATA;

--- a/newsstand/data/tabNewsData.js
+++ b/newsstand/data/tabNewsData.js
@@ -1,0 +1,751 @@
+// 수연님의 하루를 갈아 만든 데이터입니당 ^^...
+// 출처: 최수연
+
+export const TAB_NEWS_DATA = {
+  data: [
+    {
+      newsTabs: [
+        {
+          tabName: "종합/경제",
+          category: "comprehensive",
+          tabData: [
+            {
+              mediaName: "경향신문",
+              sourceLogo: "assets/news/logo/kyunghyang.svg",
+              newsDate: "2023.02.10. 12:34",
+              subscribe: "N",
+              mainNews: {
+                thumbnailImage:
+                  "https://img.khan.co.kr/news/2024/07/06/rcv.YNA.20240705.PYH2024070501770001300_P1.webp",
+                newsTitle:
+                  "민주당, 검찰총장에 “허세 부리지 말고 김 여사 수사나 제대로”",
+                url: "https://www.khan.co.kr/politics/assembly/article/202407061302001/",
+              },
+              subNews: [
+                {
+                  newsTitle:
+                    "일 자민당, 9월20일 총재 선거 검토…“기시다에 불출마 압력 커져”",
+                  url: "https://www.khan.co.kr/world/japan/article/202407061524001/",
+                },
+                {
+                  newsTitle:
+                    "중국서 2번째 큰 담수호 ‘둥팅호’ 제방 220ｍ 유실…주민 긴급 대피",
+                  url: "https://www.khan.co.kr/world/china/article/202407061643001/",
+                },
+                {
+                  newsTitle: "‘온건 개혁파’ 페제시키안, 이란 대선 승리",
+                  url: "https://www.khan.co.kr/world/mideast-africa/article/202407061256001/",
+                },
+                {
+                  newsTitle: "고장난 우산…버리면 쓰레기, 수리하면 애착 우산",
+                  url: "https://www.khan.co.kr/life/life-general/article/202407060900001/",
+                },
+                {
+                  newsTitle:
+                    "법원 “삼청교육대 ‘보호감호’ 피해자들에 국가 배상해야”",
+                  url: "https://www.khan.co.kr/national/national-general/article/202407061448001/",
+                },
+                {
+                  newsTitle:
+                    "경찰 수사심의위, ‘채상병 사건’ 임성근 전 사단장 불송치 의견",
+                  url: "https://khan.co.kr/politics/politics-general/article/202407060909001/",
+                },
+              ],
+            },
+            {
+              mediaName: "YTN",
+              sourceLogo: "assets/news/logo/ytn.svg",
+              newsDate: "2023.02.10. 11:11",
+              subscribe: "N",
+              mainNews: {
+                thumbnailImage:
+                  "https://image.ytn.co.kr/general/jpg/2022/0413/202204131632445371_t.jpg",
+                newsTitle:
+                  '\'김 여사 문자\' 후폭풍 확산..."전대 개입" vs "해당 행위"',
+                url: "https://www.ytn.co.kr/_cs/_ln_0101_202407061753597028_005.html",
+              },
+              subNews: [
+                {
+                  newsTitle:
+                    '식을 줄 모르는 푸바오 신드롬..."정치적 해석은 문제"',
+                  url: "https://www.ytn.co.kr/_cs/_ln_0106_202407061046567285_005.html",
+                },
+                {
+                  newsTitle:
+                    "'시청역 역주행 차량' 사고 이력만 6번...향후 수사는?",
+                  url: "https://www.ytn.co.kr/_cs/_ln_0103_202407061044130005_005.html",
+                },
+                {
+                  newsTitle:
+                    '허웅 정당방위 주장에 "양측 모두 폭행으로 처벌 가능"',
+                  url: "https://www.ytn.co.kr/_cs/_ln_0103_202407061255278223_005.html",
+                },
+                {
+                  newsTitle:
+                    "크로아티아 한국 관광객↑...동포 자영업자들도 기대감",
+                  url: "https://www.ytn.co.kr/_cs/_ln_0104_202407061124456629_005.html",
+                },
+                {
+                  newsTitle: "부산 해수욕장 전면 개장...해무·파도에 입수 통제",
+                  url: "https://www.ytn.co.kr/_cs/_ln_0115_202407061555440602_005.html",
+                },
+                {
+                  newsTitle: "러시아, 우크라이나 에너지 시설 공격 재개",
+                  url: "https://www.ytn.co.kr/_cs/_ln_0104_202407061738147756_005.html",
+                },
+              ],
+            },
+            {
+              mediaName: "SBSBiz",
+              sourceLogo: "assets/news/logo/sbsBiz.svg",
+              newsDate: "2023.02.10. 11:11",
+              subscribe: "Y",
+              mainNews: {
+                thumbnailImage:
+                  "https://img.sbs.co.kr/newimg/news/20240706/201954883_1280.jpg",
+                newsTitle: "서울역 인근서 고령 운전자 차량 돌진…행인 2명 치어",
+                url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007711972",
+              },
+              subNews: [
+                {
+                  newsTitle:
+                    "코레일 서울 본부서 화재 완진…인근 도로 한때 전면 통제",
+                  url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007712027",
+                },
+                {
+                  newsTitle:
+                    "이란 대선, 무명의 '개혁파' 페제시키안 당선…54% 득표",
+                  url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007711980",
+                },
+                {
+                  newsTitle:
+                    "민주, 경찰 '임성근 불송치' 의견에 \"대통령 입맛에 맞춘 요식 행위\"",
+                  url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007712009",
+                },
+                {
+                  newsTitle: '"역주행인 줄 몰랐다"…충돌 직전에야 "어, 어!"',
+                  url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007711584",
+                },
+                {
+                  newsTitle: '"드디어 사고 났다" SNS 대화방서 환호…53명 검거',
+                  url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007711595",
+                },
+                {
+                  newsTitle:
+                    "울산 '식수원' 회야댐 상류서 물고기 수십마리 잇단 폐사",
+                  url: "https://news.sbs.co.kr/news/endPage.do?news_id=N1007712071",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          tabName: "방송/통신",
+          category: "broadcast",
+          tabData: [
+            {
+              mediaName: "매일경제",
+              sourceLogo: "assets/news/logo/maeil.svg",
+              newsDate: "2023.02.10. 20:27",
+              subscribe: "N",
+              mainNews: {
+                thumbnailImage:
+                  "https://wimg.mk.co.kr/news/cms/202407/06/news-p.v1.20240706.fd08c99031b04720a87b4cc7897f4fc2_P1.jpg",
+                newsTitle:
+                  "“해변이 온 통 피바다”…섬에 놀러왔다 상어에 물린 美엄마 ‘끔찍’",
+                url: "https://www.mk.co.kr/news/world/11060549",
+              },
+              subNews: [
+                {
+                  newsTitle:
+                    "폭염에 이틀째 정전이라니 어쩌나…410가구 아파트 주민 불편",
+                  url: "https://www.mk.co.kr/news/society/11060544",
+                },
+                {
+                  newsTitle:
+                    "“차라리 알바를 하고 말지”…9급 공무원 초임 월급보니 ‘충격’",
+                  url: "https://www.mk.co.kr/news/society/11060462",
+                },
+                {
+                  newsTitle:
+                    "“가서 앉아있으면 되나”…현금 5천만원 발견된 아파트 화단서 또 나왔다",
+                  url: "https://www.mk.co.kr/news/society/11060440",
+                },
+                {
+                  newsTitle:
+                    "“몸에서 냄새 나잖아”…직장 동료 세탁기에 강제로 넣고 돌린 日남성",
+                  url: "https://www.mk.co.kr/news/world/11060523",
+                },
+                {
+                  newsTitle:
+                    "“쌍욕하다 걸리면 껍데기 벗기겠다”…어느 식당 주인의 경고문, 왜?",
+                  url: "https://www.mk.co.kr/news/society/11060502",
+                },
+                {
+                  newsTitle:
+                    "24개 학교서 1000여명 식중독 의심…김치 하나에 난리 난 남원시",
+                  url: "https://www.mk.co.kr/news/society/11060486",
+                },
+              ],
+            },
+            {
+              mediaName: "연합뉴스TV",
+              sourceLogo: "assets/news/logo/yonhap.svg",
+              newsDate: "2023.02.10. 18:27",
+              subscribe: "Y",
+              mainNews: {
+                thumbnailImage:
+                  "https://img0.yna.co.kr/photo/yna/YH/2024/01/04/PYH2024010414600001300_P4.jpg",
+                newsTitle:
+                  '유소년 경기서 욕설·폭언…손웅정측 "답답해 거친 표현"',
+                url: "https://www.yonhapnewstv.co.kr/news/MYH20240706007700032",
+              },
+              subNews: [
+                {
+                  newsTitle: "9급 공무원, 월급 최저임금보다 16만원 더 받아",
+                  url: "https://www.yonhapnewstv.co.kr/news/MYH20240706006700641",
+                },
+                {
+                  newsTitle: '초저출산 시대 위기 해법은…"사회 개혁 함께해야"',
+                  url: "https://www.yonhapnewstv.co.kr/news/MYH20240706002800641",
+                },
+                {
+                  newsTitle:
+                    "코레일 서울본부 전산센터 불…일부 역 발권기 '먹통'",
+                  url: "https://www.yonhapnewstv.co.kr/news/MYH20240706007900641",
+                },
+                {
+                  newsTitle: "사건·사고로 얼룩진 美 독립기념일…최소 26명 사망",
+                  url: "https://www.yonhapnewstv.co.kr/news/MYH20240706006000641",
+                },
+                {
+                  newsTitle:
+                    "바이든 '설욕전' 조기 성사되나…\"트럼프 제안 수용할 것\"",
+                  url: "https://www.yonhapnewstv.co.kr/news/MYH20240706008300032",
+                },
+                {
+                  newsTitle:
+                    "[단독] 온라인수출 1위는 음반 쇼핑몰…K팝이 쿠팡 추월해",
+                  url: "https://www.yonhapnewstv.co.kr/news/MYH20240706000400641",
+                },
+              ],
+            },
+            {
+              mediaName: "세계일보",
+              sourceLogo: "assets/news/logo/segye.svg",
+              newsDate: "2023.02.10. 11:11",
+              subscribe: "Y",
+              mainNews: {
+                thumbnailImage:
+                  "https://img.segye.com/content/image/2024/07/05/20240705508906.jpg",
+                newsTitle: "일상화된 ‘저강도 도발’… 북한의 노림수는",
+                url: "https://www.segye.com/newsView/20240705508875",
+              },
+              subNews: [
+                {
+                  newsTitle:
+                    "비가 이어지는 기간?…이젠 장마도 폭염·폭우 공존 ‘양극화’ [날씨+]",
+                  url: "https://www.segye.com/newsView/20240705511450",
+                },
+                {
+                  newsTitle:
+                    "민주, 검찰총장에 “허세 그만…김건희 수사나 제대로 하라” 일침",
+                  url: "https://www.segye.com/newsView/20240706504146",
+                },
+                {
+                  newsTitle:
+                    "바이든 “나 40살처럼 보이지 않나”…연설서 두 차례나 강조",
+                  url: "https://www.segye.com/newsView/20240706504090",
+                },
+                {
+                  newsTitle:
+                    "몸값 높아지는 서울 ‘소형 아파트’…사회초년생 주거 부담 강화 우려도",
+                  url: "https://www.segye.com/newsView/20240705511297",
+                },
+                {
+                  newsTitle:
+                    "[내일날씨] 습하고 더운 날씨 지속…충청·남부지방 강한 비",
+                  url: "https://www.segye.com/newsView/20240706504922",
+                },
+                {
+                  newsTitle:
+                    "이번엔 서울역서 80대 운전자가…행인 2명 치고, 벽 들이받은 후 멈춰",
+                  url: "https://www.segye.com/newsView/20240706504441",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          tabName: "IT",
+          category: "it",
+          tabData: [
+            {
+              mediaName: "조선일보",
+              sourceLogo: "assets/news/logo/chosun.svg",
+              newsDate: "2023.12.10. 11:27",
+              subscribe: "Y",
+              mainNews: {
+                thumbnailImage:
+                  "https://imgnews.pstatic.net/image/023/2024/07/06/0003844628_001_20240706160012847.jpg?type=w647",
+                newsTitle:
+                  "서울역 인근서 80대 운전자 인도 돌진…시민 2명 차로 치어",
+                url: "https://n.news.naver.com/article/023/0003844628",
+              },
+              subNews: [
+                {
+                  newsTitle:
+                    "“머스크 형님, 믿습니다. 테멘”...테슬라 주가, 올해 처음으로 수익률 플러스 전환",
+                  url: "https://n.news.naver.com/article/023/0003844603",
+                },
+                {
+                  newsTitle:
+                    "이영지, 가정사 고백...”집 나간 아버지, 이젠 모르는 아저씨”",
+                  url: "https://n.news.naver.com/article/023/0003844612",
+                },
+                {
+                  newsTitle:
+                    "붉은 피로 물든 바다…해변서 놀던 美 여성, 상어에게 물렸다",
+                  url: "https://n.news.naver.com/article/023/0003844602",
+                },
+                {
+                  newsTitle:
+                    "이들의 잘못된 만남…좋아하는 사람 만났다고 친구 폭행·감금한 20대",
+                  url: "https://n.news.naver.com/article/023/0003844636",
+                },
+                {
+                  newsTitle:
+                    "‘갑질 의혹’ 강형욱, 사실상 본업 복귀…반려견 교육 유튜브 재개",
+                  url: "https://n.news.naver.com/article/023/0003844635",
+                },
+                {
+                  newsTitle: "日 지하철 탔다가 나비 크기에 식겁...어떻길래",
+                  url: "https://n.news.naver.com/article/023/0003844627",
+                },
+              ],
+            },
+            {
+              mediaName: "동아일보",
+              sourceLogo: "assets/news/logo/donga.svg",
+              newsDate: "2023.03.13. 18:27",
+              subscribe: "N",
+              mainNews: {
+                thumbnailImage:
+                  "https://imgnews.pstatic.net/image/020/2024/07/06/0003574812_001_20240706150510496.jpg",
+                newsTitle:
+                  "‘시청역 역주행 사고’ 가해차량, 최근 6년간 6번 사고 이력",
+                url: "https://n.news.naver.com/article/020/0003574812",
+              },
+              subNews: [
+                {
+                  newsTitle:
+                    "줄서도 못사는 두바이초콜릿 먹어보니… “왜 인기인지 알겠다”",
+                  url: "https://n.news.naver.com/article/020/0003574796",
+                },
+                {
+                  newsTitle:
+                    "“사이판 수영장서 1초만에 전신마비”…무사 귀국한 유튜버의 뒷 이야기",
+                  url: "https://n.news.naver.com/article/020/0003574811",
+                },
+                {
+                  newsTitle:
+                    "“이 길을 어떻게 오르라고” 상명대 ‘지옥의 오르막’ 버스 중단 고심",
+                  url: "https://n.news.naver.com/article/020/0003574793",
+                },
+                {
+                  newsTitle:
+                    "점당 200원 ‘고스톱’ 쳤다가 법정 선 70대 노인들…법원 “심심풀이·치매예방”",
+                  url: "https://n.news.naver.com/article/020/0003574801",
+                },
+                {
+                  newsTitle:
+                    "“얼마나 피로했을까”…시청역 앞 놓인 ‘숙취해소제’에 울컥",
+                  url: "https://n.news.naver.com/article/020/0003574658",
+                },
+                {
+                  newsTitle:
+                    "“손흥민 떴다!” 동네 축구장에 깜짝등장…순식간 2000명 몰려 경찰투입",
+                  url: "https://n.news.naver.com/article/020/0003574795",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          tabName: "영자지",
+          category: "entertainment",
+          tabData: [
+            {
+              mediaName: "서울신문",
+              sourceLogo: "assets/news/logo/seoul.svg",
+              newsDate: "2023.04.15. 18:27",
+              subscribe: "Y",
+              mainNews: {
+                thumbnailImage:
+                  "https://imgnews.pstatic.net/image/081/2024/07/06/0003462874_001_20240706213311195.jpg",
+                newsTitle:
+                  "“도대체 당신 누구야”…유명 식당 여주인은 그놈에게 끝내 ‘청부살해’ 당했다[전국부 사건창고]",
+                url: "https://n.news.naver.com/article/081/0003462874",
+              },
+              subNews: [
+                {
+                  newsTitle:
+                    "“내가 좋아하는 女 만나?”…친구 4시간 감금·폭행한 20대들",
+                  url: "https://n.news.naver.com/article/081/0003462892",
+                },
+                {
+                  newsTitle:
+                    "대낮 길거리서 60대母 둔기로 폭행한 30대 아들 체포",
+                  url: "https://n.news.naver.com/article/081/0003462895",
+                },
+                {
+                  newsTitle:
+                    "한동훈, 김건희 문자 ‘읽씹’ 논란 “사적대화 부적절”…나경원 “구차 변명”",
+                  url: "https://n.news.naver.com/article/081/0003462886",
+                },
+                {
+                  newsTitle:
+                    "“소변색이 왜이래” 운동 열심히 했는데…갑자기 ‘콜라색’ 된 이유",
+                  url: "https://n.news.naver.com/article/081/0003462884",
+                },
+                {
+                  newsTitle:
+                    "“노인네들 운전대 잡지마라”…시청역 사고 후 ‘노인 비하’ 도 넘었다",
+                  url: "https://n.news.naver.com/article/081/0003462880",
+                },
+                {
+                  newsTitle:
+                    "진성준 “어디다 대고” 배현진 “뭐 뭐 쳐봐”…몸싸움 직전 일촉즉발",
+                  url: "https://n.news.naver.com/article/081/0003462879",
+                },
+              ],
+            },
+            {
+              mediaName: "한겨레",
+              sourceLogo: "assets/news/logo/hankyoreh.svg",
+              newsDate: "2024.04.10. 18:27",
+              subscribe: "Y",
+              mainNews: {
+                thumbnailImage:
+                  "https://imgnews.pstatic.net/image/028/2024/07/05/0002696883_001_20240706181017816.jpg",
+                newsTitle:
+                  "‘김건희’ 전면 등장 이상한 전당대회…한동훈과 진실 공방 번지나",
+                url: "https://n.news.naver.com/article/028/0002696883",
+              },
+              subNews: [
+                {
+                  newsTitle:
+                    "백화점이 돈 풀자 이불집·반찬집·정육점 사장님 줄줄이 검찰청으로",
+                  url: "https://n.news.naver.com/article/028/0002696917",
+                },
+                {
+                  newsTitle:
+                    "‘페미 집게손가락’ 망상…이번에도 받아 준 기업 잘못이다",
+                  url: "https://n.news.naver.com/article/028/0002696896",
+                },
+                {
+                  newsTitle:
+                    "임성근 빠진 경찰 수사심의…“시간 끌더니 대통령 입맛대로”",
+                  url: "https://n.news.naver.com/article/028/0002696925",
+                },
+                {
+                  newsTitle:
+                    "코레일 서울본부 전산실 화재…전국 대부분 역 현장발권 차질",
+                  url: "https://n.news.naver.com/article/028/0002696921",
+                },
+                {
+                  newsTitle:
+                    "백화점이 돈 풀자 이불집·반찬집·정육점 사장님 줄줄이 검찰청으로",
+                  url: "https://n.news.naver.com/article/028/0002696917",
+                },
+                {
+                  newsTitle:
+                    "서방 관계 개선·히잡 완화 공약…이란 대선, 개혁파 후보 당선",
+                  url: "https://n.news.naver.com/article/028/0002696924",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          tabName: "스포츠/연예",
+          category: "sports",
+          tabData: [
+            {
+              mediaName: "문화일보",
+              sourceLogo: "assets/news/logo/munhwa.svg",
+              newsDate: "2023.09.10. 18:27",
+              subscribe: "N",
+              mainNews: {
+                thumbnailImage:
+                  "https://imgnews.pstatic.net/image/021/2024/07/06/0002647014_001_20240706141911138.jpg",
+                newsTitle:
+                  "“푸틴, 김정은에 우크라 파병 요구… 김정은 확답 안 해”",
+                url: "https://n.news.naver.com/article/021/0002647014",
+              },
+              subNews: [
+                {
+                  newsTitle:
+                    "서울역 인근서 80대 운전 차량 인도 행인 2명 잇따라 치어",
+                  url: "https://n.news.naver.com/article/021/0002647025",
+                },
+                {
+                  newsTitle:
+                    "80대 환자에 급히 죽 떠먹여 질식사시킨 요양보호사…2심도 유죄",
+                  url: "https://n.news.naver.com/article/021/0002647026",
+                },
+                {
+                  newsTitle: "‘네카오’ 시총 올해 15조 증발…외국인 보유율 감소",
+                  url: "https://n.news.naver.com/article/021/0002647000",
+                },
+                {
+                  newsTitle: "주유소 기름값 2주 연속 상승…전국 평균 ‘1682.2원’",
+                  url: "https://n.news.naver.com/article/021/0002646994",
+                },
+                {
+                  newsTitle:
+                    "“재료값 내려갔다고 삼계탕 가격이 싸질까요?” 아니예요",
+                  url: "https://n.news.naver.com/article/021/0002646981",
+                },
+                {
+                  newsTitle:
+                    "‘9만전자 눈 앞’…삼성전자 3% 급등해 3년5개월만에 최고치",
+                  url: "https://n.news.naver.com/article/021/0002646958",
+                },
+              ],
+            },
+            {
+              mediaName: "국민일보",
+              sourceLogo: "assets/news/logo/kookmin.svg",
+              newsDate: "2024.10.30. 18:27",
+              subscribe: "Y",
+              mainNews: {
+                thumbnailImage:
+                  "https://imgnews.pstatic.net/image/005/2024/07/06/2024070605322412876_1720211544_0020279245_20240706064407477.jpg",
+                newsTitle: "이전 ‘급발진 주장’ 블랙박스 보니…“가속페달만 6번”",
+                url: "https://n.news.naver.com/article/005/0001708786",
+              },
+              subNews: [
+                {
+                  newsTitle:
+                    "남원 학교 식중독 의심환자 1000명 넘어… 사흘 만에 800명 급증",
+                  url: "https://n.news.naver.com/article/005/0001708803",
+                },
+                {
+                  newsTitle:
+                    "한동훈, 원희룡 당 선관위 신고 “인신공격성 문자 보내”",
+                  url: "https://n.news.naver.com/article/005/0001708806",
+                },
+                {
+                  newsTitle:
+                    "이번엔 서울역 인근서… 80대 운전자 차량 인도 덮쳐\n",
+                  url: "https://n.news.naver.com/article/005/0001708807",
+                },
+                {
+                  newsTitle: "바이든 “내가 트럼프 이길 것”…신체검사는 ‘거부’",
+                  url: "https://n.news.naver.com/article/005/0001708800",
+                },
+                {
+                  newsTitle:
+                    "“손흥민, 용인 조축 떴다” 2천명 몰려 난리…경찰 출동",
+                  url: "https://n.news.naver.com/article/005/0001708792",
+                },
+                {
+                  newsTitle:
+                    "‘채상병 사건’ 경찰 심의위 “임성근 전 사단장 불송치”",
+                  url: "https://n.news.naver.com/article/005/0001708796",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          tabName: "매거진/전문지",
+          category: "magazine",
+          tabData: [
+            {
+              mediaName: "데일리안",
+              sourceLogo: "assets/news/logo/dailyan.svg",
+              newsDate: "2022.02.22. 18:27",
+              subscribe: "Y",
+              mainNews: {
+                thumbnailImage:
+                  "https://cdnimage.dailian.co.kr/news/202407/news_1720067848_1379800_m_1.jpeg",
+                newsTitle:
+                  "화성시, 1조원 규모ASML-삼성전자 연구지원시설 투자유치 성공",
+                url: "https://www.dailian.co.kr/news/view/1379800/",
+              },
+              subNews: [
+                {
+                  newsTitle: '크래프톤 "카카오게임즈 인수 검토 사실무근"',
+                  url: "https://www.dailian.co.kr/news/view/1380387/",
+                },
+                {
+                  newsTitle:
+                    "[단독] \"안철수 제명하라\"...'채상병 특검법' 찬성에 與 내부 '부글부글'",
+                  url: "https://www.dailian.co.kr/news/view/1380193/",
+                },
+                {
+                  newsTitle:
+                    "아버지도 버린 노소영의 '1조3808억', 노태우 회고록엔… [데스크 칼럼]",
+                  url: "https://www.dailian.co.kr/news/view/1380187/",
+                },
+                {
+                  newsTitle: "안산 학원 화장실서 여고생 찌른 남학생 결국 사망",
+                  url: "https://www.dailian.co.kr/news/view/1380218/",
+                },
+                {
+                  newsTitle:
+                    "한동훈이 던진 '채상병 특검 수정안'…당심 움직일 카드될까 [정국 기상대]",
+                  url: "https://www.dailian.co.kr/news/view/1379985/",
+                },
+                {
+                  newsTitle:
+                    "사고만 나면 급발진?…가속페달 7번 밟고 '급발진 주장' 사례도",
+                  url: "https://www.dailian.co.kr/news/view/1380221/",
+                },
+              ],
+            },
+            {
+              mediaName: "아이뉴스",
+              sourceLogo: "assets/news/logo/inews.svg",
+              newsDate: "2021.01.11. 11:07",
+              subscribe: "Y",
+              mainNews: {
+                thumbnailImage:
+                  "https://image.inews24.com/v1/d78daaadfcbb27.jpg",
+                newsTitle:
+                  "'히잡 단속 완화' 개혁파 페제시키안 이란 대통령 당선",
+                url: "https://www.inews24.com/view/1738954",
+              },
+              subNews: [
+                {
+                  newsTitle: '"기름 넣기 무섭네"… 주유소 기름값 2주째 상승',
+                  url: "https://www.inews24.com/view/1738957",
+                },
+                {
+                  newsTitle:
+                    "22대 국회 초유의 극한 대립…'협치' 열쇠는 尹 손에 [여의뷰]",
+                  url: "https://www.inews24.com/view/1738873",
+                },
+                {
+                  newsTitle:
+                    "'교섭단체 요건 완화' 목소리 키우지만…등 돌린 '국힘·민주'",
+                  url: "https://www.inews24.com/view/1738883",
+                },
+                {
+                  newsTitle: "尹, 3년 연속 나토정상회의 참석…다음주 방미",
+                  url: "https://www.inews24.com/view/1738847",
+                },
+                {
+                  newsTitle:
+                    "검찰총장, '검사 탄핵' 위법성 검토에…민주당 \"내란행위\"",
+                  url: "https://www.inews24.com/view/1738740",
+                },
+                {
+                  newsTitle:
+                    "반지하주택 문제 어떻게 할 것인가?…경기도, 12일 국회서 토론회",
+                  url: "https://www.inews24.com/view/1738542",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          tabName: "지역",
+          category: "region",
+          tabData: [
+            {
+              mediaName: "MBN",
+              sourceLogo: "assets/news/logo/mbn.svg",
+              newsDate: "2026.06.16. 18:27",
+              subscribe: "N",
+              mainNews: {
+                thumbnailImage:
+                  "https://img.mbn.co.kr/filewww/news/2024/07/06/17202538806688fdb82f103.jpg",
+                newsTitle: "'한국은 없네'…가장 이민가고 싶은 나라 1위는?",
+                url: "https://www.mbn.co.kr/news/world/5039680",
+              },
+              subNews: [
+                {
+                  newsTitle:
+                    '한동훈 "김 여사 문자 논란, 전당대회 개입이자 당무 개입"',
+                  url: "https://www.mbn.co.kr/news/politics/5039698",
+                },
+                {
+                  newsTitle: "[날씨] 주말, 다시 전국 비…폭염특보 확대·강화",
+                  url: "https://mbn.co.kr/news/life/5039578",
+                },
+                {
+                  newsTitle:
+                    "조정훈-장경태-천하람이 본 '한동훈-김건희 문자 논란'",
+                  url: "https://www.mbn.co.kr/news/society/5039575",
+                },
+                {
+                  newsTitle:
+                    "한동훈 '배신자론'…김건희 여사 문자 무시 때문이었나?",
+                  url: "https://www.mbn.co.kr/news/society/5039574",
+                },
+                {
+                  newsTitle: "이란 대통령에 개혁파 페제시키안 당선…55% 득표",
+                  url: "https://www.mbn.co.kr/news/world/5039703",
+                },
+                {
+                  newsTitle:
+                    '바이든 "사퇴 없다. 인지력 검사 필요 없어" 정면 돌파',
+                  url: "https://www.mbn.co.kr/news/world/5039696",
+                },
+              ],
+            },
+            {
+              mediaName: "아시아경제",
+              sourceLogo: "assets/news/logo/asia.svg",
+              newsDate: "2020.02.20. 18:27",
+              subscribe: "Y",
+              mainNews: {
+                thumbnailImage:
+                  "https://cphoto.asiae.co.kr/listimglink/1/2024070617161542351_1720253775.jpg",
+                newsTitle:
+                  "\"최저임금 수준에 청년공무원 떠나\"…공무원노조 '임금인상' 집회",
+                url: "https://www.asiae.co.kr/article/2024070617173383186",
+              },
+              subNews: [
+                {
+                  newsTitle: "AB형·O형 부부서 O형 아이 나오자 난리난 집안",
+                  url: "https://www.asiae.co.kr/article/2024070509485160391",
+                },
+                {
+                  newsTitle:
+                    '"내가 누군지 알아?"…지각해 비행기 못타자 난동피운 정치인',
+                  url: "https://www.asiae.co.kr/article/2024070508173074446",
+                },
+                {
+                  newsTitle:
+                    "주차비 아까워 앞차 꽁무니 '바짝'…3억 벤틀리의 꼼수",
+                  url: "https://www.asiae.co.kr/article/2024070514003800977",
+                },
+                {
+                  newsTitle:
+                    '"냄새난다"며 지적장애 동료 세탁기에 넣어…"정신나갔다" 日 공분',
+                  url: "https://www.asiae.co.kr/article/2024070509362498806",
+                },
+                {
+                  newsTitle:
+                    '"개 찾아주고 한달 500만원 이상 법니다"…중국서 뜨는 직업',
+                  url: "https://www.asiae.co.kr/article/2024070510191072960",
+                },
+                {
+                  newsTitle:
+                    "연일 사상최고치 인도증시…월가 “고점 멀었다” 하는 이유",
+                  url: "https://www.asiae.co.kr/article/world-economy/2024070510185366615",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export default TAB_NEWS_DATA;

--- a/newsstand/src/app/App.js
+++ b/newsstand/src/app/App.js
@@ -1,8 +1,7 @@
 import AutoRollingNews from "../components/autoRollingNews/autoRollingNews.js";
 import Header from "../views/header/header.js";
 import Headline from "../views/headline/headline.js";
-import NewsList from "../views/newsList/newsList.js";
-import { PressMenu } from "../views/pressMenu/pressMenu.js";
+import Main from "../views/main/main.js";
 
 // App 컴포넌트
 export const App = () => {
@@ -13,8 +12,7 @@ export const App = () => {
         <div class="main-container">
             <div class="header"></div>
             <div class="headline"></div>
-            <div class="press-menu"></div>
-            <div class="newsList"></div>
+            <div class="main"></div>
         </div>
     `;
 
@@ -45,32 +43,17 @@ export const App = () => {
         headlineContainer.appendChild(headline.element);
     }
 
-    function makePressMenu(appContainer) {
-        const className ="press-menu"
-        const pressMenuContainer = appContainer.querySelector(`.${className}`);
+    function makeMain(appContainer) {
+        const className = "main"
+        const mainContainer = appContainer.querySelector(`.${className}`);
 
-        if (!pressMenuContainer) {
-            console.log(`not founded pressMenu container with className ${className}`)
+        if (!mainContainer) {
+            console.log(`not founded main container with className ${className}`)
             return;
         }
 
-        const pressMenu = PressMenu();
-    
-        pressMenuContainer.appendChild(pressMenu.element);
-    }
-
-    function makeNewsList(appContainer) {
-        const className = "newsList"
-        const newsListContainer = appContainer.querySelector(`.${className}`);
-
-        if (!newsListContainer) {
-            console.log(`not founded newsList container with className ${className}`)
-            return;
-        }
-
-        const newsList = NewsList();
-
-        newsListContainer.appendChild(newsList.element);
+        const main = Main();
+        mainContainer.appendChild(main.element);
     }
 
     function initializeApp() {
@@ -78,8 +61,7 @@ export const App = () => {
 
         makeHeader(appContainer);
         makeHeadline(appContainer);
-        makePressMenu(appContainer);
-        makeNewsList(appContainer);
+        makeMain(appContainer);
 
         const appDiv = document.getElementById('app');
         if (appDiv) {

--- a/newsstand/src/components/autoRollingNews/autoRollingNews.css
+++ b/newsstand/src/components/autoRollingNews/autoRollingNews.css
@@ -20,13 +20,14 @@
     color: var(--color-text-strong);
 }
 
-.autoRollingNews-title {
+/* .autoRollingNews-title {
+    padding: 0;
     height: 17px;
 
     font-weight: var(--font-weight-medium);
     font-size: var(--font-size-regular);
     color: var(--color-text-default);
-}
+} */
 
 .autoRollingNews-title:hover {
     text-decoration: underline;
@@ -36,13 +37,17 @@
     opacity: 0;
     height: 17px;
 
-    transform: translateY(20px);
+    font-weight: var(--font-weight-medium);
+    font-size: var(--font-size-regular);
+    color: var(--color-text-default);
+
+    transform: translateY(5px);
     transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
 .autoRollingNews-item.animate-out {
     opacity: 0;
-    transform: translateY(20px);
+    transform: translateY(5px);
 }
 
 .autoRollingNews-item.animate-in {

--- a/newsstand/src/components/autoRollingNews/autoRollingNews.js
+++ b/newsstand/src/components/autoRollingNews/autoRollingNews.js
@@ -63,9 +63,7 @@ export const AutoRollingNews = (props) => {
 
         const html = `
             <p class="autoRollingNews-company">${press}</p>
-            <div class="autoRollingNews-item animate-out">
-                <a class="autoRollingNews-title" href="${link}">${title}</a>
-            </div>
+            <a class="autoRollingNews-item animate-out" href="${link}">${title}</a>
         `;
         element.innerHTML = html;
 

--- a/newsstand/src/components/chipButton/chipButton.css
+++ b/newsstand/src/components/chipButton/chipButton.css
@@ -1,3 +1,23 @@
-.chipButton {
-    
+.chip-button {
+    background-color: var(--color-surface-alt);
+    border: var(--border-default);
+
+    border-radius: 50px;
+
+    font-weight: var(--font-weight-medium);
+    font-size: var(--font-size-small);
+    color: var(--color-text-weak);
+
+    width: max-content;
+    height:12px;
+
+    display: flex;
+    justify-content: center;
+
+    padding: 5px;
+}
+
+.chip-button-icon {
+    width: 12px;
+    height: 12px;
 }

--- a/newsstand/src/components/chipButton/chipButton.js
+++ b/newsstand/src/components/chipButton/chipButton.js
@@ -1,7 +1,28 @@
-export const ChipButton = () => {
-	return {
-    	element: `<div>ChipButton</div>`
+export const ChipButton = (props) => {
+    let element = document.createElement('div');
+    element.className = 'chip-button-container';
+
+    function render() {
+        const html = `
+            <div class="chip-button">
+                <img class="chip-button-icon" src=${props.icon} alt="icon"></img>
+                <span>${props.title}</span>
+            </div>
+        `;
+        element.innerHTML = html;
+    }
+
+    function updateProps(newProps) {
+        props = newProps;
+        render();
+    }
+
+    render();
+
+    return {
+        element,
+        updateProps
     };
-}
+};
 
 export default ChipButton;

--- a/newsstand/src/components/snackBar/snackBar.css
+++ b/newsstand/src/components/snackBar/snackBar.css
@@ -1,7 +1,53 @@
-.snackBar {
+/* .snack-bar {
+    visibility: hidden;
+
+    position: fixed;
+    z-index: 1;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    transition: opacity 0.5s, visibility 0s 0.5s;
+    opacity: 0;
+
     width: max-content  ;
     color: var(--color-text-white-default);
     box-shadow: var(--box-shadow);
     padding: 16px 24px 16px 24px;
     background-color: var(--color-surface-brand-default);
+} */
+
+.snackbar-container {
+    position: fixed;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 9999;
+}
+
+.snack-bar {
+    visibility: hidden;
+    text-align: center;
+    transition: opacity 0.5s, visibility 0s 0.5s;
+    opacity: 0;
+
+    width: max-content  ;
+    color: var(--color-text-white-default);
+    box-shadow: var(--box-shadow);
+    padding: 16px 24px 16px 24px;
+    background-color: var(--color-surface-brand-default);
+
+    font-size: var(--font-size-medium);
+    font-weight: var(--font-weight-medium);
+}
+
+
+.snack-bar.show {
+    visibility: visible;
+    opacity: 1;
+    transition: opacity 0.5s, visibility 0s 0s;
+}
+
+.snack-bar.hide {
+    opacity: 0;
+    transition: opacity 0.5s, visibility 0s 0.5s;
 }

--- a/newsstand/src/components/snackBar/snackBar.js
+++ b/newsstand/src/components/snackBar/snackBar.js
@@ -1,10 +1,37 @@
-import { createElement } from '../../app/createElement.js';
+export const SnackBar = (props) => {
+  let element = document.createElement("div");
+  element.className = "snackbar-container";
 
-export const SnackBar = () => {
+  function render() {
+      const html = `
+          <div class="snack-bar">${props.title}</div>
+      `;
+      element.innerHTML = html;
+  }
+
+  function show() {
+      document.body.appendChild(element);
+      const snackBarElement = element.querySelector('.snack-bar');
+
+      setTimeout(() => {
+          snackBarElement.classList.add("show");
+      }, 100);
+
+      setTimeout(() => {
+          snackBarElement.classList.remove("show");
+          snackBarElement.classList.add("hide");
+      }, 3100);
+
+      setTimeout(() => {
+          document.body.removeChild(element);
+      }, 3600);
+  }
+
+  render();
+
   return {
-    element: `
-    <div class="snackBar" id="snackBarContent"> 내가 구독한 언론사에 추가되었습니다.</div>
-  `
+      element,
+      show
   };
 };
 

--- a/newsstand/src/utils/utils.js
+++ b/newsstand/src/utils/utils.js
@@ -1,0 +1,5 @@
+
+export function separateId(id) {
+    const parts = id.split('-');
+    return parseInt(parts[parts.length - 1], 10);
+}

--- a/newsstand/src/views/main/main.js
+++ b/newsstand/src/views/main/main.js
@@ -1,0 +1,97 @@
+import NewsList from "../newsList/newsList.js";
+import PressMenu from "../pressMenu/pressMenu.js";
+import TAB_NEWS_DATA from "../../../data/tabNewsData.js";
+
+export const Main = () => {
+  let isAllPress = true;
+  let isList = true;
+
+  let element = document.createElement("div");
+  element.className = "main-container";
+
+  function render() {
+    const pressMenu = PressMenu({onToggleAllPress, onToggleListView});
+
+    const html = ``;
+
+    element.innerHTML = html;
+    element.appendChild(pressMenu.element);
+
+    const contentContainer = document.createElement("div");
+    contentContainer.className = "main-content-container";
+    element.appendChild(contentContainer);
+
+    isList ? makeNewsList(contentContainer) : makePressGrid(contentContainer);
+  }
+
+  render();
+
+  return {
+    element,
+  };
+
+  function createTabs() {
+    let tabs = isAllPress ? getAllPressTabs() : getSubscribedPressTabs();
+    return tabs;
+  }
+
+  function makeNewsList(element) {
+    element.innerHTML = "";
+
+    const tabs = createTabs();
+    const newsList = NewsList({tabs});
+
+    element.appendChild(newsList.element);
+
+    console.log("46");
+  }
+
+  function makePressGrid(element) {
+    element.innerHTML = "";
+    element.appendChild();
+
+    console.log("53");
+  }
+
+  function getAllPressTabs() {
+    const filteredTabNames = TAB_NEWS_DATA.data
+      .map((tab) => {
+        return tab.newsTabs.map((newsTab) => {
+          return newsTab.tabName;
+        });
+      })
+      .flat();
+
+    return filteredTabNames;
+  }
+
+  function getSubscribedPressTabs() {
+    const subscribedPressTabsString = localStorage.getItem("pressId");
+
+    if (!subscribedPressTabsString) {
+      console.log("no subscribed press");
+      return [];
+    }
+
+    try {
+      const subscribedPressTabsArray = JSON.parse(subscribedPressTabsString);
+      return subscribedPressTabsArray;
+    } catch (error) {
+      console.error("Error parsing subscribed press tabs:", error);
+      return [];
+    }
+  }
+
+  function onToggleAllPress(newValue) {
+    isAllPress = newValue;
+    render();
+  }
+
+  function onToggleListView(newValue) {
+    isList = newValue;
+    console.log(isList);
+    render();
+  }
+};
+
+export default Main;

--- a/newsstand/src/views/main/main.js
+++ b/newsstand/src/views/main/main.js
@@ -42,28 +42,26 @@ export const Main = () => {
     const newsList = NewsList({tabs});
 
     element.appendChild(newsList.element);
-
-    console.log("46");
   }
 
   function makePressGrid(element) {
     element.innerHTML = "";
     element.appendChild();
-
-    console.log("53");
   }
 
   function getAllPressTabs() {
-    const filteredTabNames = TAB_NEWS_DATA.data
-      .map((tab) => {
-        return tab.newsTabs.map((newsTab) => {
-          return newsTab.tabName;
-        });
-      })
-      .flat();
-
-    return filteredTabNames;
-  }
+    const tabDataWithCounts = TAB_NEWS_DATA.data.flatMap((tab) => {
+      return tab.newsTabs.map((newsTab) => {
+        return {
+          tabName: newsTab.tabName,
+          tabDataIndex: 0,
+          tabDataCount: newsTab.tabData.length
+        };
+      });
+    });
+  
+    return tabDataWithCounts;
+  }  
 
   function getSubscribedPressTabs() {
     const subscribedPressTabsString = localStorage.getItem("pressId");

--- a/newsstand/src/views/newsList/newsList.js
+++ b/newsstand/src/views/newsList/newsList.js
@@ -2,47 +2,47 @@ import PressCategoryContainer from './pressCategory/pressCategory.js';
 import PressInfoContainer from './pressInfo/pressInfo.js';
 import PressNewsContainer from './pressNews/pressNews.js';
 
+import { separateId } from '../../utils/utils.js';
+
 export const NewsList = (props) => {
     let element = document.createElement('div');
     element.className = 'news-container';
 
     const { tabs } = props;
 
-    let selectedId = 'press-category-0';
+    let selectedCategoryIndex = 0;
+    let selectedPressIndex = 0;
+    let lastSelectedCategoryIndex = null;
 
-    let pressCategoryContainer = PressCategoryContainer({
-        tabs,
-        selectedId, 
-        onChangeCategory: handleChangeCategory
-    });
-
-    function handleChangeCategory(newSelectedId) {
-        if (newSelectedId !== selectedId) {
-            selectedId = newSelectedId;
-            pressCategoryContainer.updateSelectedId(newSelectedId);
-            render();
-        }
-    }
+    let pressCategoryContainer;
 
     function render() {
         const html = `
-            <img src="../../assets/icons/left-arrow-button.svg" alt="left arrow icon">
+            <img id="left-arrow" class="arrow-button" src="../../assets/icons/left-arrow-button.svg" alt="left arrow icon">
             <div class="news-content-container"></div>
-            <img src="../../assets/icons/right-arrow-button.svg" alt="right arrow icon">
+            <img id="right-arrow" class="arrow-button" src="../../assets/icons/right-arrow-button.svg" alt="right arrow icon">
         `;
 
         element.innerHTML = html;
 
         const newsContentContainer = element.querySelector('.news-content-container');
 
-        const pressInfoContainer = PressInfoContainer({ 
-            imageSrc: "", 
-            editTime: "2023.02.10. 18:57 편집" 
+        if (!pressCategoryContainer || lastSelectedCategoryIndex !== selectedCategoryIndex) {
+            pressCategoryContainer = PressCategoryContainer({
+                tabs,
+                selectedId: `press-category-${selectedCategoryIndex}`,
+                onChangeCategory: handleChangeCategory
+            });
+        }
+
+        const pressInfoContainer = PressInfoContainer({
+            imageSrc: "",
+            editTime: "2023.02.10. 18:57 편집"
         });
 
-        const pressNewsContainer = PressNewsContainer({ 
+        const pressNewsContainer = PressNewsContainer({
             mainNews: {
-                imageSrc: "https://wimg.mk.co.kr/news/cms/202407/04/news-p.v1.20240704.0b9bafd4ae364e1a8827d570d63bbf41_P1.jpg", 
+                imageSrc: "https://wimg.mk.co.kr/news/cms/202407/04/news-p.v1.20240704.0b9bafd4ae364e1a8827d570d63bbf41_P1.jpg",
                 title: "대통령실, 도이치모터스 1심 판결에 '김 여사 연루 의혹, 민주당 주장 깨졌다'"
             },
             listNews: [
@@ -55,9 +55,88 @@ export const NewsList = (props) => {
             ]
         });
 
+        newsContentContainer.innerHTML = '';
         newsContentContainer.appendChild(pressCategoryContainer.element);
         newsContentContainer.appendChild(pressInfoContainer.element);
         newsContentContainer.appendChild(pressNewsContainer.element);
+
+
+        addEventListenerToArrowButton();
+
+        lastSelectedCategoryIndex = selectedCategoryIndex;
+    }
+
+    function handleChangeCategory(newSelectedId) {
+        console.log(selectedCategoryIndex);
+        console.log(newSelectedId);
+        if (newSelectedId !== `press-category-${selectedCategoryIndex}`) {
+            selectedCategoryIndex = separateId(newSelectedId);
+            console.log(selectedCategoryIndex);
+            render();
+        }
+    }
+
+    function addEventListenerToArrowButton() {
+        const buttons = element.querySelectorAll('.arrow-button');
+
+        buttons.forEach(button => {
+            button.addEventListener('click', changePressCategory);
+        });
+    }
+
+    function changePressCategory(event) {
+        switch (event.target.id) {
+            case "left-arrow":
+                changeToPrevPress();
+                break;
+            case "right-arrow":
+                changeToNextPress();
+                break;
+            default:
+                break;
+        }
+    }
+
+    function changeToNextCategory() {
+        selectedCategoryIndex += 1;
+
+        if (selectedCategoryIndex >= tabs.length) {
+            selectedCategoryIndex = 0;
+        }
+
+        console.log(selectedCategoryIndex);
+
+        render();
+    }
+
+    function changeToPrevCategory() {
+        selectedCategoryIndex -= 1;
+
+        if (selectedCategoryIndex < 0) {
+            selectedCategoryIndex = tabs.length - 1;
+        }
+
+        console.log(selectedCategoryIndex);
+        render();
+    }
+
+    function changeToNextPress() {
+        selectedPressIndex += 1;
+
+        if (selectedPressIndex > 3) {
+            selectedPressIndex = 0;
+            changeToNextCategory();
+        }
+    }
+
+    function changeToPrevPress() {
+        console.log("press prev");
+        selectedPressIndex -= 1;
+
+        if (selectedPressIndex < 0) {
+            selectedPressIndex = 0;
+            changeToPrevCategory();
+        }
     }
 
     render();
@@ -65,6 +144,6 @@ export const NewsList = (props) => {
     return {
         element
     };
-}
+};
 
 export default NewsList;

--- a/newsstand/src/views/newsList/newsList.js
+++ b/newsstand/src/views/newsList/newsList.js
@@ -10,10 +10,10 @@ export const NewsList = (props) => {
 
     const { tabs } = props;
 
+    let timerIntervalRef = { current: null };
     let selectedCategoryIndex = 0;
     let selectedPressIndex = 0;
     let lastSelectedCategoryIndex = null;
-
     let pressCategoryContainer;
 
     function render() {
@@ -27,13 +27,14 @@ export const NewsList = (props) => {
 
         const newsContentContainer = element.querySelector('.news-content-container');
 
-        if (!pressCategoryContainer || lastSelectedCategoryIndex !== selectedCategoryIndex) {
-            pressCategoryContainer = PressCategoryContainer({
-                tabs,
-                selectedId: `press-category-${selectedCategoryIndex}`,
-                onChangeCategory: handleChangeCategory
-            });
-        }
+        pressCategoryContainer = PressCategoryContainer({
+            tabs,
+            timerIntervalRef,
+            selectedId: `press-category-${selectedCategoryIndex}`,
+            selectedPressIndex: selectedPressIndex,
+            onChangeCategory: handleChangeCategory,
+            onChangePress: handleChangePress
+        });
 
         const pressInfoContainer = PressInfoContainer({
             imageSrc: "",
@@ -60,18 +61,21 @@ export const NewsList = (props) => {
         newsContentContainer.appendChild(pressInfoContainer.element);
         newsContentContainer.appendChild(pressNewsContainer.element);
 
-
         addEventListenerToArrowButton();
 
         lastSelectedCategoryIndex = selectedCategoryIndex;
     }
 
     function handleChangeCategory(newSelectedId) {
-        console.log(selectedCategoryIndex);
-        console.log(newSelectedId);
         if (newSelectedId !== `press-category-${selectedCategoryIndex}`) {
             selectedCategoryIndex = separateId(newSelectedId);
-            console.log(selectedCategoryIndex);
+            render();
+        }
+    }
+
+    function handleChangePress(newSelectedId) { 
+        if (selectedPressIndex !== newSelectedId) {
+            selectedPressIndex = newSelectedId;
             render();
         }
     }
@@ -80,7 +84,10 @@ export const NewsList = (props) => {
         const buttons = element.querySelectorAll('.arrow-button');
 
         buttons.forEach(button => {
-            button.addEventListener('click', changePressCategory);
+            button.addEventListener('click', (event) => {
+                changePressCategory(event);
+                pressCategoryContainer.setTimer(); // 화살표 버튼 클릭 시 타이머 초기화
+            });
         });
     }
 
@@ -95,16 +102,41 @@ export const NewsList = (props) => {
             default:
                 break;
         }
-    }
 
+        if (timerIntervalRef.current) {
+            console.log("clearTimer", timerIntervalRef.current);
+            clearInterval(timerIntervalRef.current);
+        }
+    }
+    
+    function changeToNextPress() {
+        selectedPressIndex += 1;
+
+        if (selectedPressIndex >= tabs[selectedCategoryIndex].tabDataCount) {
+            selectedPressIndex = 0;
+            changeToNextCategory();
+        }
+
+        render();
+    }
+    
+    function changeToPrevPress() {
+        selectedPressIndex -= 1;
+
+        if (selectedPressIndex < 0) {
+            selectedPressIndex = 0;
+            changeToPrevCategory();
+        }
+
+        render();
+    }
+    
     function changeToNextCategory() {
         selectedCategoryIndex += 1;
 
         if (selectedCategoryIndex >= tabs.length) {
             selectedCategoryIndex = 0;
         }
-
-        console.log(selectedCategoryIndex);
 
         render();
     }
@@ -116,27 +148,7 @@ export const NewsList = (props) => {
             selectedCategoryIndex = tabs.length - 1;
         }
 
-        console.log(selectedCategoryIndex);
         render();
-    }
-
-    function changeToNextPress() {
-        selectedPressIndex += 1;
-
-        if (selectedPressIndex > 3) {
-            selectedPressIndex = 0;
-            changeToNextCategory();
-        }
-    }
-
-    function changeToPrevPress() {
-        console.log("press prev");
-        selectedPressIndex -= 1;
-
-        if (selectedPressIndex < 0) {
-            selectedPressIndex = 0;
-            changeToPrevCategory();
-        }
     }
 
     render();

--- a/newsstand/src/views/newsList/newsList.js
+++ b/newsstand/src/views/newsList/newsList.js
@@ -6,8 +6,12 @@ export const NewsList = (props) => {
     let element = document.createElement('div');
     element.className = 'news-container';
 
+    const { tabs } = props;
+
     let selectedId = 'press-category-0';
+
     let pressCategoryContainer = PressCategoryContainer({
+        tabs,
         selectedId, 
         onChangeCategory: handleChangeCategory
     });

--- a/newsstand/src/views/newsList/pressCategory/pressCategory.css
+++ b/newsstand/src/views/newsList/pressCategory/pressCategory.css
@@ -24,6 +24,7 @@
     width: 0;
     height: 100%;
     transition: width 1s ease;
+    /* background-color: var(--color-surface-brand-default);s */
 
     z-index: -100;
 }

--- a/newsstand/src/views/newsList/pressCategory/pressCategory.css
+++ b/newsstand/src/views/newsList/pressCategory/pressCategory.css
@@ -7,9 +7,8 @@
 .press-category-button {
     height: 100%;
     color: var(--color-text-weak);
-    text-align: center;
-
-    text-transform: uppercase;
+    padding: 0px 16px 0px 16px;
+    margin: 0px;
 
     position: relative;
     cursor: pointer;
@@ -23,8 +22,28 @@
     left: 0;
     width: 0;
     height: 100%;
-    transition: width 1s ease;
-    /* background-color: var(--color-surface-brand-default);s */
-
+    background-color: var(--color-surface-brand-default);
     z-index: -100;
+}
+
+.press-category-button-progress.selected {
+    animation: widthAnimation 20s linear infinite;
+}
+
+@keyframes widthAnimation {
+    0% {
+        width: 0%;
+    }
+
+    100% {
+        width: 100%;
+    }
+}
+
+.press-category-span-container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }

--- a/newsstand/src/views/newsList/pressCategory/pressCategory.js
+++ b/newsstand/src/views/newsList/pressCategory/pressCategory.js
@@ -5,7 +5,7 @@ export const ProgressCategoryContainer = ({ selectedId: initialSelectedId, onCha
     let progressButtons = [];
     let selectedId = initialSelectedId;
     let progressInterval;
-    let autoChangeCategoryTimeout;
+
     const rootStyles = getComputedStyle(document.documentElement);
     const categories = [
         { id: 0, title: "종합/경제", nowIndex: 1, total: 4 },
@@ -34,7 +34,6 @@ export const ProgressCategoryContainer = ({ selectedId: initialSelectedId, onCha
 
         if (categories[currentId].nowIndex < categories[currentId].total) {
             categories[currentId].nowIndex += 1;
-            console.log(categories[currentId].nowIndex);
             updateSelectedButtonStyle(buttons[currentId]);
         } else {
             const nextId = (currentId + 1) % categories.length;
@@ -45,27 +44,35 @@ export const ProgressCategoryContainer = ({ selectedId: initialSelectedId, onCha
 
     function onClickEvent(event) {
         clearCurrentInterval();
-        const id = `press-category-${separateId(event.target.id)}`;
+        const intId = separateId(event.target.id);
+        const id = `press-category-${intId}}`;
         if (id !== selectedId) {
             onChangeCategory(id);
+        } else {
+            updateSelectedButtonStyle(buttons[intId]);
         }
     }
 
     function updateSelectedButtonStyle(selectedButton) {
+        const id = separateId(selectedButton.id)
         const categoryCount = selectedButton.querySelector(`#category-count`);
+
         if (categoryCount) {
-            categoryCount.remove();
+            categoryCount.textContent = `${categories[id].nowIndex}/${categories[id].total}`;
+        } else {
+            addCountElement(selectedButton);
         }
+
         buttons.forEach((button, index) => {
             progressButtons[index].style.width = 0;
             progressButtons[index].style.backgroundColor = 'transparent';
             button.style.backgroundColor = 'transparent';
             button.style.color = rootStyles.getPropertyValue('--color-text-weak');
         });
+
         selectedButton.style.backgroundColor = rootStyles.getPropertyValue('--color-surface-brand-alt');
         selectedButton.style.color = rootStyles.getPropertyValue('--color-text-white-default');
         setProgress(selectedButton);
-        addCountElement(selectedButton);
     }
 
     function addCountElement(selectedButton) {
@@ -80,13 +87,17 @@ export const ProgressCategoryContainer = ({ selectedId: initialSelectedId, onCha
     function setProgress(selectedButton) {
         clearCurrentInterval();
         const progressElement = progressButtons[separateId(selectedButton.id)];
+        
         if (progressElement) {
             let progress = 0;
+            progressElement.style.transition = 'width 1s ease';
+            
             progressInterval = setInterval(() => {
                 if (progress >= 100) {
+                    clearInterval(progressInterval);
+                    progressElement.style.transition = 'none';
                     progressElement.style.width = 0;
                     progressElement.style.backgroundColor = 'transparent';
-                    clearInterval(progressInterval);
                     autoChangeCategory();
                 } else {
                     progress += 2;
@@ -96,6 +107,7 @@ export const ProgressCategoryContainer = ({ selectedId: initialSelectedId, onCha
             }, 400);
         }
     }
+    
 
     function render() {
         const html = categories.map(category => `

--- a/newsstand/src/views/newsList/pressCategory/pressCategory.js
+++ b/newsstand/src/views/newsList/pressCategory/pressCategory.js
@@ -1,4 +1,4 @@
-export const ProgressCategoryContainer = ({ selectedId: initialSelectedId, onChangeCategory }) => {
+export const ProgressCategoryContainer = ({ tabs, selectedId: initialSelectedId, onChangeCategory }) => {
     let element = document.createElement('div');
     element.className = 'press-category-container';
     let buttons = [];
@@ -7,15 +7,17 @@ export const ProgressCategoryContainer = ({ selectedId: initialSelectedId, onCha
     let progressInterval;
 
     const rootStyles = getComputedStyle(document.documentElement);
-    const categories = [
-        { id: 0, title: "종합/경제", nowIndex: 1, total: 4 },
-        { id: 1, title: "방송/통신", nowIndex: 1, total: 4 },
-        { id: 2, title: "IT", nowIndex: 1, total: 4 },
-        { id: 3, title: "영자지", nowIndex: 1, total: 4 },
-        { id: 4, title: "스포츠/연예", nowIndex: 1, total: 4 },
-        { id: 5, title: "매거진/전문지", nowIndex: 1, total: 4 },
-        { id: 6, title: "지역", nowIndex: 1, total: 4 }
-    ];
+    const categories = transformTabsToCategories(tabs);
+
+    function transformTabsToCategories(tabs) {
+        if (!tabs) { return; }
+        return tabs.map((tab, index) => ({
+            id: index,
+            title: tab,
+            nowIndex: 1,
+            total: 4
+        }));
+    }    
 
     function separateId(id) {
         const parts = id.split('-');

--- a/newsstand/src/views/newsList/pressCategory/pressCategory.js
+++ b/newsstand/src/views/newsList/pressCategory/pressCategory.js
@@ -1,126 +1,122 @@
 import { separateId } from "../../../utils/utils.js";
 
-export const ProgressCategoryContainer = ({ tabs, selectedId: initialSelectedId, onChangeCategory }) => {
+const ProgressCategoryContainer = ({ 
+    tabs, 
+    timerIntervalRef,  // Use a ref to manage the timer interval
+    selectedId: initialSelectedId, 
+    selectedPressIndex: initialSelectedPressIndex, 
+    onChangeCategory, 
+    onChangePress 
+    }) => {
+
     const element = document.createElement('div');
     element.className = 'press-category-container';
 
     let buttons = [];
     let progressBars = [];
+    let selectedPressIndex = initialSelectedPressIndex;
     let selectedId = initialSelectedId;
-    let progressInterval;
-    let lastIndexUpdate = null;
-
-    const rootStyles = getComputedStyle(document.documentElement);
-    const categories = transformTabsToCategories(tabs);
-
-    function transformTabsToCategories(tabs) {
-        return tabs.map((tab, index) => ({
-            id: index,
-            title: tab,
-            nowIndex: 1,
-            total: 4,
-        }));
-    } 
-
-    function clearCurrentInterval() {
-        if (progressInterval) {
-            clearInterval(progressInterval);
-        }
-    }
 
     function autoChangeCategory() {
+        console.log('auto');
         const currentIndex = separateId(selectedId);
-        const currentCategory = categories[currentIndex];
+        const currentCategory = tabs[currentIndex];
 
-        if (currentCategory.nowIndex < currentCategory.total) {
-            currentCategory.nowIndex += 1;
-            updateCategoryIndex(currentCategory.nowIndex);
+        if (selectedPressIndex < currentCategory.tabDataCount - 1) {
+            selectedPressIndex += 1;
+            onChangePress(selectedPressIndex);
         } else {
-            const nextId = (currentIndex + 1) % categories.length;
+            const nextId = (currentIndex + 1) % tabs.length;
             const newSelectedId = `press-category-${nextId}`;
             onChangeCategory(newSelectedId);
+            onChangePress(0);
         }
-    }
 
-    function updateCategoryIndex(index) {
-        if (lastIndexUpdate !== index) {
-            lastIndexUpdate = index;
-            onChangeCategoryIndex(index);
-        }
+        updateSelectedButtonStyle(currentIndex);
     }
 
     function onClickEvent(event) {
-        clearCurrentInterval();
+        setTimer();
+
         const intId = separateId(event.target.id);
         const id = `press-category-${intId}`;
 
         if (id !== selectedId) {
             onChangeCategory(id);
+            onChangePress(0);
         } else {
             updateSelectedButtonStyle(intId);
         }
     }
 
     function updateSelectedButtonStyle(id) {
+        const rootStyles = getComputedStyle(document.documentElement);
+
         buttons.forEach((button, index) => {
             const isSelected = index === id;
+
             button.style.backgroundColor = isSelected ? rootStyles.getPropertyValue('--color-surface-brand-alt') : 'transparent';
             button.style.color = isSelected ? rootStyles.getPropertyValue('--color-text-white-default') : rootStyles.getPropertyValue('--color-text-weak');
-            progressBars[index].style.width = isSelected ? '100%' : 0;
-            progressBars[index].style.backgroundColor = isSelected ? rootStyles.getPropertyValue('--color-surface-brand-default') : 'transparent';
 
-            const categoryCount = button.querySelector('#category-count');
-            if (categoryCount) {
-                const category = categories[index];
-                categoryCount.textContent = `${category.nowIndex}/${category.total}`;
+            const categoryCountSpan = button.querySelector('.press-count-span');
+            if (categoryCountSpan) {
+                button.style.width = isSelected ? "166px" : "max-content";
+                categoryCountSpan.textContent = isSelected ? `${selectedPressIndex + 1}/${tabs[index].tabDataCount}` : "";
+            }
+
+            if (isSelected) {
+                progressBars[index].classList.add('selected');
+            } else {
+                progressBars[index].classList.remove('selected');
             }
         });
     }
 
-    function createButton(category) {
+    function createButton(category, index) {
         const button = document.createElement('button');
         button.className = 'press-category-button';
-        button.id = `press-category-${category.id}`;
+        button.id = `press-category-${index}`;
 
         const progressBar = document.createElement('div');
         progressBar.className = 'press-category-button-progress';
-        progressBar.id = `press-category-progress-${category.id}`;
+        progressBar.id = `press-category-${index}`;
 
-        const span = document.createElement('span');
-        span.id = `press-category-span-${category.id}`;
-        span.textContent = category.title;
+        const container = document.createElement('div');
+        container.className = 'press-category-span-container';
+        container.id = `press-category-${index}`;
+
+        const tabNameSpan = document.createElement('span');
+        tabNameSpan.id = `press-category-${index}`;
+        tabNameSpan.textContent = category.tabName;
+
+        const countSpan = document.createElement('span');
+        countSpan.id = `press-category-${index}`;
+        countSpan.className = `press-count-span`;
+        countSpan.textContent = '';
+
+        container.appendChild(tabNameSpan);
+        container.appendChild(countSpan);
 
         button.appendChild(progressBar);
-        button.appendChild(span);
+        button.appendChild(container);
         return button;
     }
 
-    function setProgress(selectedButton) {
-        const id = separateId(selectedButton.id);
-        const progressElement = progressBars[id];
-
-        let progress = 0;
-        progressElement.style.transition = 'width 1s ease';
-
-        progressInterval = setInterval(() => {
-            if (progress >= 100) {
-                clearInterval(progressInterval);
-                progressElement.style.transition = 'none';
-                progressElement.style.width = 0;
-                progressElement.style.backgroundColor = 'transparent';
-                autoChangeCategory();
-            } else {
-                progress += 2;
-                progressElement.style.width = `${progress}%`;
-                progressElement.style.backgroundColor = rootStyles.getPropertyValue('--color-surface-brand-default');
-            }
-        }, 100);
+    function setTimer() {
+        if (timerIntervalRef.current) {
+            console.log("clearTimer", timerIntervalRef.current);
+            clearInterval(timerIntervalRef.current);
+        }
+        timerIntervalRef.current = setInterval(autoChangeCategory, 20000);
+        console.log("settimer:", timerIntervalRef.current);
     }
 
     function renderButtons() {
         element.innerHTML = '';
-        categories.forEach(category => {
-            const button = createButton(category);
+        buttons = [];
+        progressBars = [];
+        tabs.forEach((category, index) => {
+            const button = createButton(category, index);
             element.appendChild(button);
             buttons.push(button);
             progressBars.push(button.querySelector('.press-category-button-progress'));
@@ -133,16 +129,18 @@ export const ProgressCategoryContainer = ({ tabs, selectedId: initialSelectedId,
         });
     }
 
-    function initialize() {
+    function render() {
         renderButtons();
         addEventListeners();
         updateSelectedButtonStyle(separateId(selectedId));
     }
 
-    initialize();
+    render();
+    setTimer();
 
     return {
-        element
+        element,
+        setTimer
     };
 };
 

--- a/newsstand/src/views/newsList/pressInfo/pressInfo.js
+++ b/newsstand/src/views/newsList/pressInfo/pressInfo.js
@@ -5,12 +5,14 @@ export const PressInfoContainer = (props) => {
     let element = document.createElement('div');
     element.className = 'press-info-container';
 
+    let isSubscribed = props.isSubscribed;  
+
     function render() {
         const chipButton = makeChipButton();
         
         const html = `
-        <img src="${props.imageSrc}" alt="press image"/>
-        <span class="press-info-edit-date">${props.editTime}</span>
+            <img src="${props.imageSrc}" alt="press image"/>
+            <span class="press-info-edit-date">${props.editTime}</span>
         `;
     
         element.innerHTML = html;
@@ -18,24 +20,31 @@ export const PressInfoContainer = (props) => {
     }
 
     function makeChipButton() {
-        const icon = props.isSubscribed ? '/newsstand/assets/icons/xmark.svg' : '/newsstand/assets/icons/plus.svg'
-        const chipButton = ChipButton({ icon: icon, title: '구독하기' });
+        const icon = isSubscribed ? '/newsstand/assets/icons/xmark.svg' : '/newsstand/assets/icons/plus.svg';
+        const title = isSubscribed ? '구독 취소' : '구독하기';
+        const chipButton = ChipButton({ icon: icon, title: title });
 
         chipButton.element.addEventListener('click', subscribePress);
-        return chipButton
+        return chipButton;
     }
 
     function subscribePress() {
         savePressToStorage();
         showSnackBar();
+        render();
     }
 
     function showSnackBar() {
-        const snackBar = SnackBar({title: '내가 구독한 언론사에 추가되었습니다.'});
+        isSubscribed = !isSubscribed;
+        const snackBar = SnackBar({ title: '내가 구독한 언론사에 추가되었습니다.' });
         snackBar.show();
     }
 
     function savePressToStorage() {
+        let pressId = "경제신문";
+        let subscribedPress = localStorage.getItem('pressId');
+
+        subscribedPress += pressId;
         localStorage.setItem('pressId', pressId);
     }
 

--- a/newsstand/src/views/newsList/pressInfo/pressInfo.js
+++ b/newsstand/src/views/newsList/pressInfo/pressInfo.js
@@ -21,7 +21,7 @@ export const PressInfoContainer = (props) => {
 
     function makeChipButton() {
         const icon = isSubscribed ? '/newsstand/assets/icons/xmark.svg' : '/newsstand/assets/icons/plus.svg';
-        const title = isSubscribed ? '구독 취소' : '구독하기';
+        const title = isSubscribed ? '' : '구독하기';
         const chipButton = ChipButton({ icon: icon, title: title });
 
         chipButton.element.addEventListener('click', subscribePress);

--- a/newsstand/src/views/newsList/pressInfo/pressInfo.js
+++ b/newsstand/src/views/newsList/pressInfo/pressInfo.js
@@ -1,15 +1,42 @@
+import ChipButton from "../../../components/chipButton/chipButton.js";
+import SnackBar from "../../../components/snackBar/snackBar.js";
+
 export const PressInfoContainer = (props) => {
     let element = document.createElement('div');
     element.className = 'press-info-container';
 
     function render() {
-        const html = `
-            <img src="${props.imageSrc}" />
-            <span class="press-info-edit-date">${props.editTime}</span>
-            <button>구독하기</button>
-        `;
+        const chipButton = makeChipButton();
         
+        const html = `
+        <img src="${props.imageSrc}" alt="press image"/>
+        <span class="press-info-edit-date">${props.editTime}</span>
+        `;
+    
         element.innerHTML = html;
+        element.appendChild(chipButton.element);
+    }
+
+    function makeChipButton() {
+        const icon = props.isSubscribed ? '/newsstand/assets/icons/xmark.svg' : '/newsstand/assets/icons/plus.svg'
+        const chipButton = ChipButton({ icon: icon, title: '구독하기' });
+
+        chipButton.element.addEventListener('click', subscribePress);
+        return chipButton
+    }
+
+    function subscribePress() {
+        savePressToStorage();
+        showSnackBar();
+    }
+
+    function showSnackBar() {
+        const snackBar = SnackBar({title: '내가 구독한 언론사에 추가되었습니다.'});
+        snackBar.show();
+    }
+
+    function savePressToStorage() {
+        localStorage.setItem('pressId', pressId);
     }
 
     render();

--- a/newsstand/src/views/pressMenu/pressMenu.js
+++ b/newsstand/src/views/pressMenu/pressMenu.js
@@ -1,20 +1,51 @@
-export const PressMenu = () => {
+export const PressMenu = ({ onToggleAllPress, onToggleListView }) => {
     let element = document.createElement('div');
     element.className = 'press-menu-container';
 
+    function toggleSubscribeButton(event) {
+        const button = event.target;
+        button.style.fontWeight = 'bold';
+
+        onToggleAllPress(button.id === 'all-press');
+    }
+
+    function toggleListView(event) {
+        const button = event.target;
+
+        console.log("toggle");
+        onToggleListView(button.id === 'list-view');
+    }
+
     function render() {
         const html = `
-        <div class="subscribe-menu-container">
-            <button class="subscribe-menu-button">전체 언론사</button>
-            <button class="subscribe-menu-button">내가 구독한 언론사</button>
-        </div>
-        <div>
-            <img src="../../assets/icons/list-view.svg" alt="list view icon">
-            <img src="../../assets/icons/grid-view.svg" alt="grid view icon">
-        </div>
-    `;
+            <div class="subscribe-menu-container">
+                <button id="all-press" class="subscribe-menu-button">전체 언론사</button>
+                <button id="subscribed-press" class="subscribe-menu-button">내가 구독한 언론사</button>
+            </div>
+            <div>
+                <img id="list-view" src="../../assets/icons/list-view.svg" alt="list view icon" class="list-grid-button">
+                <img id="grid-view" src="../../assets/icons/grid-view.svg" alt="grid view icon" class="list-grid-button">
+            </div>
+        `;
 
-    element.innerHTML = html;
+        element.innerHTML = html;
+
+        addEventListenerToSubscribeButtons();
+        addEventListenerToListButtons();
+    }
+
+    function addEventListenerToSubscribeButtons() {
+        const subscribeButtons = element.querySelectorAll('.subscribe-menu-button');
+        subscribeButtons.forEach(button => {
+            button.addEventListener('click', toggleSubscribeButton);
+        });
+    }
+
+    function addEventListenerToListButtons() {
+        const listGridButtons = element.querySelectorAll('.list-grid-button');
+        listGridButtons.forEach(button => {
+            button.addEventListener('click', toggleListView);
+        });
     }
 
     render();

--- a/newsstand/src/views/pressMenu/pressMenu.js
+++ b/newsstand/src/views/pressMenu/pressMenu.js
@@ -11,8 +11,7 @@ export const PressMenu = ({ onToggleAllPress, onToggleListView }) => {
 
     function toggleListView(event) {
         const button = event.target;
-
-        console.log("toggle");
+        
         onToggleListView(button.id === 'list-view');
     }
 

--- a/newsstand/src/views/pressMenu/pressMenu.js
+++ b/newsstand/src/views/pressMenu/pressMenu.js
@@ -1,4 +1,3 @@
-
 export const PressMenu = () => {
     let element = document.createElement('div');
     element.className = 'press-menu-container';


### PR DESCRIPTION
## ⁉️ 작업 내용
- 부자연스러운 레이아웃을 일부 수정하였습니다.
- 부자연스러운 애니메이션 효과를 일부 수정하였습니다.
- 구독하기 버튼을 추가하고, 구독 snack bar 이벤트를 추가하였습니다. (구독 기능 추가)
- 언론사 메뉴들에 이벤트를 추가하였습니다. (구독, 전체 언론사 / 그리드, 리스트 뷰)
- 데이터 파일을 추가하였습니다.
- 데이터에 맞게 props, event를 수정하였습니다.
- 이제 arrow 버튼으로도 category 변경이 가능합니다.

<br />

## 스크린샷

- snackBar
<img width="1207" alt="image" src="https://github.com/softeerbootcamp4th/fe-newsstand/assets/62610032/85c91695-96af-4025-899b-d1778ec3b85f">


<br />


## 🔧 앞으로의 과제
- 데이터 파일을 js 파일로 작업하였는데, 추후에 json 파일로 변경하여 parsing을 추가할 예정이다.
- 데이터에 맞게 수정하다가 progress animation이 되지 않는다. 다시 animation 효과를 추가할 예정이다.
- news content에 데이터 내용을 넘겨준다.

