### PR TITLE
[서창교] Alert component구현 및 구조 재설계

### DIFF
--- a/frontend/static/assets/images/Button.svg
+++ b/frontend/static/assets/images/Button.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" y="0.5" width="23" height="23" rx="11.5" fill="white"/>
+<rect x="0.5" y="0.5" width="23" height="23" rx="11.5" stroke="#D2DAE0"/>
+<path d="M9.6 15L9 14.4L11.4 12L9 9.6L9.6 9L12 11.4L14.4 9L15 9.6L12.6 12L15 14.4L14.4 15L12 12.6L9.6 15Z" fill="#879298"/>
+</svg>

--- a/frontend/static/css/index.css
+++ b/frontend/static/css/index.css
@@ -451,3 +451,55 @@
         top: -17px;
     }
 }
+
+.alert_Container {
+    flex-direction: column;
+    position: absolute;
+    display: flex;
+    z-index: 500;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.alert_unsubscribe {
+    background-color: #FFFFFF;
+    border: #D2DAE0 1px solid;
+    width: 320px;
+    height: 140px;
+}
+
+.alert_subscribe {
+    color: white;
+    justify-content: center;
+    text-align: center;
+    width: 286px;
+    height: 54px;
+    background-color: #4362D0;
+}
+
+
+.alert_title {
+    color: #5F6E76;
+    flex-grow: 1;
+    align-content: center;
+    text-align: center;
+}
+
+.alert_button {
+    align-content: center;
+    text-align: center;
+    width: 50%;
+    height: 48px;
+    background-color: #F5F7F9;
+    border-top: #D2DAE0 1px solid;
+}
+
+.alert_button.left {
+    border-right: #D2DAE0 1px solid;
+}
+
+
+.hover-underline:hover {
+    text-decoration: underline;
+}

--- a/frontend/static/data/data.js
+++ b/frontend/static/data/data.js
@@ -22,7 +22,8 @@ const articleTitles = [
     "기후 변화, 글로벌 대응이 필요한 시점"
 ];
 
-export const NEWS = Array.from({ length: 100 }, () => ({
+export let NEWS = Array.from({ length: 100 }, (_, index) => ({
+    "id": index,
     "category": getRandomElement(categories),
     "lastDate": "2023.02.10. 18:27",
     "mediaCompanyImageURL": "https://s.pstatic.net/static/newsstand/2019/logo/011.png",

--- a/frontend/static/js/alert/alert.js
+++ b/frontend/static/js/alert/alert.js
@@ -1,0 +1,32 @@
+export function showSubscribeAlert(action) {
+    let alertContainer = document.createElement(`div`)
+    alertContainer.className = "alert_Container alert_subscribe"
+    alertContainer.innerText = "내가 구독한 언론사에 추가되었습니다."
+    document.body.appendChild(alertContainer)
+
+    setTimeout(() => {
+        document.querySelector(".alert_Container").remove()
+        action()
+    }, 5000)
+}
+
+export function showUnSubsribeAlert(companyName, action) {
+    let alertContainer = document.createElement("div")
+    alertContainer.className = "alert_Container alert_unsubscribe"
+
+    const cancelAction = () => document.querySelector(".alert_Container.alert_unsubscribe").remove()
+
+    const render = () =>
+        `<div class="alert_title"><span style="color: #14212B; font-weight: 700;">${companyName}</span>을(를)<br> 구독해지하시겠습니까?</div>
+         <div class="Layout__row">
+            <div class="alert_button left hover-underline">예, 해지합니다</div>
+            <div class="alert_button right hover-underline">아니오</div>
+         </div>
+        `
+
+    alertContainer.insertAdjacentHTML("beforeend", render());
+    alertContainer.querySelector(".alert_button.right").addEventListener('click', cancelAction)
+    alertContainer.querySelector(".alert_button.left").addEventListener('click', action)
+
+    document.body.appendChild(alertContainer);
+}

--- a/frontend/static/js/mainContentControl/pageControl.js
+++ b/frontend/static/js/mainContentControl/pageControl.js
@@ -1,10 +1,11 @@
+import { showSubscribeAlert } from "../alert/alert.js";
 
 // data는 언론사와 그안의 기사들
-export function moveToNextPage(data, currentDom, nextDom, index) {
+export function moveToNextPage(data, currentDom, nextDom, index, subscribeAction = () => { }) {
     const currentData = data[index];
     // 더미를 활용한 template literal
     console.log(currentData.mediaCompanyImageURL);
-    const template = `<div id="mainContentTitle" class="Layout__row alignItems-center gap10"><img src="${currentData.mediaCompanyImageURL}" style="width: 52.5px; height:20px;" alt="img"><span>${currentData.lastDate}편집</span><img class="modeImg" src="./static/assets/images/subscribeButton.svg" alt="Description of SVG"></div><div id="mainContentArticles" class="Layout__row"><div id="mainContentRepresentiveArticle" class="Layout__column-center"><img src="${currentData.articles[0].imageURL}" alt="Description of SVG" style="width: 320px; height: 200px"><span class="marginTop16">${currentData.articles[0].articleTitle}</span></div><div id="mainContentAritcleList"><ui><li>${currentData.articles[1].articleTitle}</li><li>${currentData.articles[2].articleTitle}</li><li>${currentData.articles[3].articleTitle}</li><li>${currentData.articles[4].articleTitle}</li><li>${currentData.articles[5].articleTitle}</li><li>${currentData.articles[6].articleTitle}</li></ui><div>${currentData.name} 언론사에서 직접 편집한 뉴스입니다.</div></div></div>`
+    const template = `<div id="mainContentTitle" class="Layout__row alignItems-center gap10"><img src="${currentData.mediaCompanyImageURL}" style="width: 52.5px; height:20px;" alt="img"><span>${currentData.lastDate}편집</span><img class="subScribeButton" src="./static/assets/images/${currentData.isSubscribe ? "Button.svg" : "subscribeButton.svg"}" alt="Description of SVG"></div><div id="mainContentArticles" class="Layout__row"><div id="mainContentRepresentiveArticle" class="Layout__column-center"><img src="${currentData.articles[0].imageURL}" alt="Description of SVG" style="width: 320px; height: 200px"><span class="marginTop16">${currentData.articles[0].articleTitle}</span></div><div id="mainContentAritcleList"><ui><li>${currentData.articles[1].articleTitle}</li><li>${currentData.articles[2].articleTitle}</li><li>${currentData.articles[3].articleTitle}</li><li>${currentData.articles[4].articleTitle}</li><li>${currentData.articles[5].articleTitle}</li><li>${currentData.articles[6].articleTitle}</li></ui><div>${currentData.name} 언론사에서 직접 편집한 뉴스입니다.</div></div></div>`
 
     // 비어져있는 다음 element에 주입
     // dom이라는 변수명을 잘 안사용한다는걸 지금봤습니다. 내일 수정하겠습니다.
@@ -27,12 +28,16 @@ export function moveToNextPage(data, currentDom, nextDom, index) {
         // 애니메이션 종료로 element들을 원래 위치로 변경
         nextDom.classList.remove("animationStartNext");
         currentDom.classList.remove("animationStartNext");
+        document.querySelector(".subScribeButton").addEventListener('click', () => {
+            showSubscribeAlert(() => { })
+            subscribeAction();
+        })
     }, 1000);
 }
 
-export function moveToPreviousPage(data, currentDom, previousDom, index) {
+export function moveToPreviousPage(data, currentDom, previousDom, index, subscribeAction = () => { }) {
     const currentData = data[index];
-    const template = `<div id="mainContentTitle" class="Layout__row alignItems-center gap10"><img src="${currentData.mediaCompanyImageURL}" style="width: 52.5px; height:20px;" alt="img"><span>${currentData.lastDate}편집</span><img class="modeImg" src="./static/assets/images/subscribeButton.svg" alt="Description of SVG"></div><div id="mainContentArticles" class="Layout__row"><div id="mainContentRepresentiveArticle" class="Layout__column-center"><img src="${currentData.articles[0].imageURL}" alt="Description of SVG" style="width: 320px; height: 200px"><span class="marginTop16">${currentData.articles[0].articleTitle}</span></div><div id="mainContentAritcleList"><ui><li>${currentData.articles[1].articleTitle}</li><li>${currentData.articles[2].articleTitle}</li><li>${currentData.articles[3].articleTitle}</li><li>${currentData.articles[4].articleTitle}</li><li>${currentData.articles[5].articleTitle}</li><li>${currentData.articles[6].articleTitle}</li></ui><div>${currentData.name} 언론사에서 직접 편집한 뉴스입니다.</div></div></div>`
+    const template = `<div id="mainContentTitle" class="Layout__row alignItems-center gap10"><img src="${currentData.mediaCompanyImageURL}" style="width: 52.5px; height:20px;" alt="img"><span>${currentData.lastDate}편집</span><img class="subScribeButton" src="./static/assets/images/${currentData.isSubscribe ? "Button.svg" : "subscribeButton.svg"}" alt="Description of SVG"></div><div id="mainContentArticles" class="Layout__row"><div id="mainContentRepresentiveArticle" class="Layout__column-center"><img src="${currentData.articles[0].imageURL}" alt="Description of SVG" style="width: 320px; height: 200px"><span class="marginTop16">${currentData.articles[0].articleTitle}</span></div><div id="mainContentAritcleList"><ui><li>${currentData.articles[1].articleTitle}</li><li>${currentData.articles[2].articleTitle}</li><li>${currentData.articles[3].articleTitle}</li><li>${currentData.articles[4].articleTitle}</li><li>${currentData.articles[5].articleTitle}</li><li>${currentData.articles[6].articleTitle}</li></ui><div>${currentData.name} 언론사에서 직접 편집한 뉴스입니다.</div></div></div>`
 
     previousDom.insertAdjacentHTML('beforeend', template);
     previousDom.classList.add("animationStartPrevious");
@@ -47,5 +52,9 @@ export function moveToPreviousPage(data, currentDom, previousDom, index) {
         currentDom.insertAdjacentHTML('beforeend', template);
         previousDom.classList.remove("animationStartPrevious");
         currentDom.classList.remove("animationStartPrevious");
+        document.querySelector(".subScribeButton").addEventListener('click', () => {
+            showSubscribeAlert(() => { })
+            subscribeAction();
+        })
     }, 1000);
 }

--- a/frontend/static/js/recentNews/rollingNews.js
+++ b/frontend/static/js/recentNews/rollingNews.js
@@ -1,4 +1,3 @@
-
 export function rollingNews(currentDom, template, isLeft) {
     const futureDom = document.querySelector(isLeft ? ".futureDom_left" : ".futureDom_right");
     while (futureDom.firstChild) {
@@ -8,7 +7,7 @@ export function rollingNews(currentDom, template, isLeft) {
     futureDom.insertAdjacentHTML('beforeend', template);
     futureDom.classList.add("futureDomStart");
 
-    setTimeout(function () {
+    setTimeout(() => {
         while (currentDom.firstChild) {
             currentDom.removeChild(currentDom.firstChild);
         }


### PR DESCRIPTION
# 구현 사항
## Alert component 
```javascript
export function showSubscribeAlert(action) {
    let alertContainer = document.createElement(`div`)
    alertContainer.className = "alert_Container alert_subscribe"
    alertContainer.innerText = "내가 구독한 언론사에 추가되었습니다."
    document.body.appendChild(alertContainer)

    setTimeout(() => {
        document.querySelector(".alert_Container").remove()
        action()
    }, 5000)
}
```
위와 같은 방식으로 createElement를 넣어서 append하고 해당 element는 absloute라서 화면 중앙에 배치하고 zindex를 줘서 상단에 뜨게 하였다.

```javascript
export function showUnSubsribeAlert(companyName, action) {
    let alertContainer = document.createElement("div")
    alertContainer.className = "alert_Container alert_unsubscribe"

    const cancelAction = () => document.querySelector(".alert_Container.alert_unsubscribe").remove()

    const render = () =>
        `<div class="alert_title"><span style="color: #14212B; font-weight: 700;">${companyName}</span>을(를)<br> 구독해지하시겠습니까?</div>
         <div class="Layout__row">
            <div class="alert_button left hover-underline">예, 해지합니다</div>
            <div class="alert_button right hover-underline">아니오</div>
         </div>
        `

    alertContainer.insertAdjacentHTML("beforeend", render());
    alertContainer.querySelector(".alert_button.right").addEventListener('click', cancelAction)
    alertContainer.querySelector(".alert_button.left").addEventListener('click', action)

    document.body.appendChild(alertContainer);
}
```
원리는 같으나 해당 element는 조금 더 복잡하여서 가독성을 높이기 위해 template literal로 작업하였다. 특정 style같은경우 static하여서 atrributes로 뺐다.
이후 구독취소버튼과 취소 버튼의 function을 외부에서 주입받도록 하였다.

## 구조 재설계
기존 방식이 재사용성, 확장성, 가독성, 성능 모두 기준치에 미치지 못하였고 이를 구조자체에 문제가 있다고 판단 주안점을 설계하고 구조를 재기획하고 있다.

### 주안점

1. 컴포넌트로 나누고 각 component는 오로지 랜더링만을 한다.
2. 각 컴포넌트와 layout사이에 hirechy를 쉽게 볼수 있어야한다. → index.js는 큰덩이의 symentic 하게 component를 의존한다. → 각 component안에서는 그 안에만을 위한 component들로 구성하고 각 컴포넌트는 외부에서 직접접근을 할 수 없도록 수정한다. → 이렇게 했을때 서로 엮여 있는 부분의 render 순서를 잘 고려해야한다→ 이런 부부은 하나로 엮는것이 올바라 보인다 → 아니면 상태관리하는 파일에서 잘 관리해야한다.
3. SEO를 고려하여 큰 덩이의 tag들은 html에 넣고 각 태그의 이름이 되는 부분들은 그냥 html로 구현한다.

### 뉴스스탠드

1. 뉴스스탠드는 기획적으로 검색시 특정 기사가 html에 바로 뜰 필요는 없다. 뉴스스탠드는 뉴스스탠드를 검색하고 들어오지 특정 기사로 뉴스스탠드로 들어오진 않는다(이런경우는 보통 바로 기사를 클릭해서 들어가지않을까? ) 그래서 현재 생각은 이것이 뉴스스탠드임을 잘 표현해야한다. SEO를 할 메인 유저는 특정 기사로 인한 유입이 아니라 뉴스스탠드라고 쳐서 들어오는 유저임 이라고 판단
    
    → 최상단과 기본 골자에 뉴스스탠드임을 녹여내서 스크립트와 별개로 이것이 뉴스스탠드임을 빠르게 보여준다.

# 결
구조자체에 대한 고민과 어느정도까지 고려해야 판단이 명확하지 않다. 하지만 실제 서비스된다는 생각을 가지고 구조를 재설계하고 있고, 상태관리를 통합하고 component와 로직을 분리하려 노력하고 있다.

# Todo
- [ ] SEO에 대한 명확한 공부 (현재 위에 설명한 것이 실제 SEO에 도움이 되는지 아직 미지수)
- [ ] 컴포넌트와 로직에 분리가 웹에 어울리는 디자인패턴인지 판단
- [ ] 특정 컴포넌트의 load순서에 따라 로직의 엉킴이 발생할 수 있는데 이를 해결하기 위한 방안 모색
- [ ] 폴더 구조를 컴포넌트 단위로 할지 목적( element, logic, util ) 위주로 할지 결정