### PR TITLE
[강준우] 옵저버 패턴 적용 및 카테고리 선택, '전체언론사', '내가 구독한 언론사' 선택 기능 구현

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -100,17 +100,20 @@
 .news-list__menu__selectors {
     display: flex;
     gap: 30px;
+    color: gray;
+}
+
+.news-list__menu__selectors [data-selected="yes"] {
+    color: black;
 }
 
 .news-list__menu__selectors__all {
     font-size: 16px;
-    color: black;
     display: inline-block;
 }
 
 .news-list__menu__selectors__my {
     font-size: 16px;
-    color: gray;
     display: inline-block;
 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -13,7 +13,7 @@ app.get('/', (req, res) => {
 })
 
 app.get('/newsList', (req, res) => {
-    if (req.query.subAllInfo === "sub") res.sendFile("./data/subscribed.json");
+    if (req.query.subAllInfo === "sub") res.sendFile(__dirname + "/data/all.json");
     else res.sendFile(__dirname + "/data/all.json");
 })
 

--- a/src/constants/message.js
+++ b/src/constants/message.js
@@ -1,3 +1,5 @@
-export const ERROR_MESSAGE = Object.freeze({
+import { deepFreeze } from "../utils/deepfreeze.js";
+
+export const ERROR_MESSAGE = deepFreeze({
     NOT_IMPLEMENTED: "메서드 구현이 필요합니다."
 })

--- a/src/data/newsDataFetcher.js
+++ b/src/data/newsDataFetcher.js
@@ -1,0 +1,15 @@
+/**
+ * 로컬 서버에서 뉴스 데이터를 가져와 json 데이터를 반환하는 함수
+ * @returns {json} - 뉴스 json 데이터
+ */
+export async function fetchAllNewsData() {
+    const allNewsResponse = await fetch(`http://127.0.0.1:8000/newsList?subAllInfo=all`);
+    const allNewsData = await allNewsResponse.json();
+    return allNewsData;
+}
+
+export async function fetchSubscribedNewsData() {
+    const subscribedNewsResponse = await fetch(`http://127.0.0.1:8000/newsList?subAllInfo=sub`);
+    const subscribedNewsData = await subscribedNewsResponse.json();
+    return subscribedNewsData
+}

--- a/src/eventHandlers/CategoryEventHandler.js
+++ b/src/eventHandlers/CategoryEventHandler.js
@@ -7,8 +7,8 @@ import { EventsHandler } from "./EventsHandler.js";
 class CategoryEventHandler extends EventsHandler {
     /**
      * @constructor
-     * @param {string} type 
-     * @param {Array} [states = 0] - 주입받는 states
+     * @param {States} states - 주입받은 states 
+     * @param {object} eventInfoList - 발생한 이벤트 리스트
      */
     constructor(states = {}, eventInfo) {
         super();
@@ -19,8 +19,9 @@ class CategoryEventHandler extends EventsHandler {
 
     /**
      * 이벤트를 등록하는 함수
-     * @param {Function} listener 
-     * @param {string} type 
+     * @param {object} eventInfoList - 발생한 이벤트 리스트
+     * @param {string} eventInfoList[].type - 등록할 이벤트 타입
+     * @param {Function} eventInfoList[].listener - 등록할 이벤트 리스너 
      */
     #addEvents(eventInfos) {
         eventInfos.forEach(({ type, listener }) => {

--- a/src/eventHandlers/CategoryEventHandler.js
+++ b/src/eventHandlers/CategoryEventHandler.js
@@ -10,11 +10,11 @@ class CategoryEventHandler extends EventsHandler {
      * @param {string} type 
      * @param {Array} [states = 0] - 주입받는 states
      */
-    constructor(type, states = {}) {
+    constructor(states = {}, eventInfo) {
         super();
         this.states = states;
         this.element = document.querySelector(".news-list__navbar");
-        this.addEvents(this.#listener.bind(this), type);
+        this.#addEvents(eventInfo);
     }
 
     /**
@@ -22,12 +22,10 @@ class CategoryEventHandler extends EventsHandler {
      * @param {Function} listener 
      * @param {string} type 
      */
-    addEvents(listener, type) {
-        this.element.addEventListener(type, listener);
-    }
-
-    #listener(event) {
-        this.states.setCategory(Array.from(this.element.children).indexOf(event.target));
+    #addEvents(eventInfos) {
+        eventInfos.forEach(({ type, listener }) => {
+            this.element.addEventListener(type, (event) => listener(event, this.states, this.element));
+        })
     }
 }
 

--- a/src/eventHandlers/SubAllEventHandler.js
+++ b/src/eventHandlers/SubAllEventHandler.js
@@ -1,0 +1,33 @@
+import { EventsHandler } from "./EventsHandler.js";
+
+/**
+ * @class SubAllEventHandler
+ * @classdesc '전체언론사', '내가 구독한 언론사' 이벤트 핸들러
+ */
+class SubAllEventHandler extends EventsHandler {
+    /**
+     * @constructor
+     * @param {States} states - 주입받은 states 
+     * @param {object} eventInfoList - 발생한 이벤트 리스트
+     */
+    constructor(states = {}, eventInfoList) {
+        super();
+        this.states = states;
+        this.element = document.querySelector(".news-list__menu__selectors");
+        this.#addEvents(eventInfoList);
+    }
+
+    /**
+     * 이벤트를 등록하는 함수
+     * @param {object} eventInfoList - 발생한 이벤트 리스트
+     * @param {string} eventInfoList[].type - 등록할 이벤트 타입
+     * @param {Function} eventInfoList[].listener - 등록할 이벤트 리스너 
+     */
+    #addEvents(eventInfoList) {
+        eventInfoList.forEach(({ type, listener }) => {
+            this.element.addEventListener(type, (event) => listener(event, this.states, this.element));
+        })
+    }
+}
+
+export { SubAllEventHandler }

--- a/src/events/categoryEvent.js
+++ b/src/events/categoryEvent.js
@@ -1,0 +1,13 @@
+export const categoryClickEventInfo = {
+    type: "click",
+    listener: (event, states, element) => {
+        states.setCategory(Array.from(element.children).indexOf(event.target))
+    }
+}
+
+export const categoryOnloadEventInfo = {
+    type: "load",
+    listener: (event, states, element) => {
+        console.log(1)
+    }
+}

--- a/src/events/categoryEvent.js
+++ b/src/events/categoryEvent.js
@@ -1,5 +1,8 @@
 import { deepFreeze } from "../utils/deepfreeze.js";
 
+/**
+ * 카테고리를 클릭 했을 때의 이벤트 정보 객체
+ */
 export const categoryClickEventInfo = deepFreeze({
     type: "click",
     listener: (event, states, element) => {
@@ -14,4 +17,7 @@ export const categoryOnloadEventInfo = deepFreeze({
     }
 })
 
-export const categoryEventTypeList = deepFreeze(["load", "click"]);
+/**
+ * Renderer에서 렌더를 허용할 이벤트 타입의 목록
+ */
+export const categoryEventTypeList = deepFreeze(["click"]);

--- a/src/events/categoryEvent.js
+++ b/src/events/categoryEvent.js
@@ -18,6 +18,6 @@ export const categoryOnloadEventInfo = deepFreeze({
 })
 
 /**
- * Renderer에서 렌더를 허용할 이벤트 타입의 목록
+ * Renderer에서 렌더를 허용할 이벤트 이름의 목록
  */
-export const categoryEventTypeList = deepFreeze(["click"]);
+export const categoryEventNameList = deepFreeze(["clickCategory"]);

--- a/src/events/categoryEvent.js
+++ b/src/events/categoryEvent.js
@@ -1,13 +1,17 @@
-export const categoryClickEventInfo = {
+import { deepFreeze } from "../utils/deepfreeze.js";
+
+export const categoryClickEventInfo = deepFreeze({
     type: "click",
     listener: (event, states, element) => {
         states.setCategory(Array.from(element.children).indexOf(event.target))
     }
-}
+})
 
-export const categoryOnloadEventInfo = {
+export const categoryOnloadEventInfo = deepFreeze({
     type: "load",
     listener: (event, states, element) => {
         console.log(1)
     }
-}
+})
+
+export const categoryEventTypeList = deepFreeze(["load", "click"]);

--- a/src/events/subAllEvent.js
+++ b/src/events/subAllEvent.js
@@ -1,0 +1,16 @@
+import { deepFreeze } from "../utils/deepfreeze.js";
+
+/**
+ * '전체언론사', '내가 구독한 언론사'를 클릭 했을 때의 이벤트 정보 객체
+ */
+export const subAllClickEventInfo = deepFreeze({
+    type: "click",
+    listener: (event, states, element) => {
+        states.setSubAll(Array.from(element.children).indexOf(event.target));
+    }
+})
+
+/**
+ * Renderer에서 렌더를 허용할 이벤트 이름의 목록
+ */
+export const subAllEventNameList = deepFreeze(["clickSubAll"]);

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,9 @@ import { CategoryRenderer } from "./renderers/CategoryRenderer.js";
 import { NewsStates } from "./states/newsStates.js";
 import { categoryClickEventInfo, categoryOnloadEventInfo } from "./events/categoryEvent.js";
 import { fetchAllNewsData, fetchSubscribedNewsData } from "./data/newsDataFetcher.js";
+import { SubAllEventHandler } from "./eventHandlers/SubAllEventHandler.js";
+import { subAllClickEventInfo } from "./events/subAllEvent.js";
+import { SubAllRenderer } from "./renderers/SubAllRenderer.js";
 
 
 const allNewsData = await fetchAllNewsData();
@@ -11,5 +14,7 @@ const subscribedNewsData = await fetchSubscribedNewsData();
 const newsStates = new NewsStates({ allNewsData, subscribedNewsData });
 
 new CategoryEventHandler(newsStates, [categoryOnloadEventInfo, categoryClickEventInfo]);
+new SubAllEventHandler(newsStates, [subAllClickEventInfo]);
 
 newsStates.subscribe(new CategoryRenderer);
+newsStates.subscribe(new SubAllRenderer);

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,15 @@
 import { CategoryEventHandler } from "./eventHandlers/CategoryEventHandler.js";
 import { CategoryRenderer } from "./renderers/CategoryRenderer.js";
 import { NewsStates } from "./states/newsStates.js";
+import { categoryClickEventInfo, categoryOnloadEventInfo } from "./events/categoryEvent.js";
+import { fetchAllNewsData, fetchSubscribedNewsData } from "./data/newsDataFetcher.js";
 
-const newsStates = new NewsStates({});
-const categoryEventHandler = new CategoryEventHandler("click", newsStates);
+
+const allNewsData = await fetchAllNewsData();
+const subscribedNewsData = await fetchSubscribedNewsData();
+
+const newsStates = new NewsStates({ allNewsData, subscribedNewsData });
+
+new CategoryEventHandler(newsStates, [categoryOnloadEventInfo, categoryClickEventInfo]);
 
 newsStates.subscribe(new CategoryRenderer);

--- a/src/renderers/CategoryRenderer.js
+++ b/src/renderers/CategoryRenderer.js
@@ -19,20 +19,31 @@ class CategoryRenderer extends Renderer {
      * @returns 
      */
     _checkEventName(event) {
-        return event.eventName === 'clickCategory';
+        return event.eventName === 'clickCategory'; // 나중에 상수 배열로 빼기
     }
 
     /**
-     * 렌더 함수
+     * 생성된 element를 렌더링하는 함수
+     * @param {object} categoryInfo - 카테고리 정보
+     * @param {number} categoryIndex - 선택된 카테고리 인덱스
+     * @param {Array} categoryList - 표시 될 카테고리 목록
      */
-    _render({ eventName, value, ...rest }) {
-        const categoryListElement = this.#generateCategoryListElement(value);
+    _render({ categoryIndex, categoryList }) {
+        const categoryListElement = this.#generateCategoryListElement(categoryIndex, categoryList);
         this.categoryContainer.innerHTML = '';
         this.categoryContainer.innerHTML += categoryListElement;
     }
 
-    #generateCategoryListElement(value) {
-        return `<div>dd</div>`
+    /**
+     * 표시될 element를 생성하는 함수
+     * @param {number} categoryIndex - 선택된 카테고리 인덱스
+     * @param {Array} categoryList - 표시 될 카테고리 목록
+     * @returns {Element}
+     */
+    #generateCategoryListElement(categoryIndex = 0, categoryList) {
+        return categoryList.map((category, index) =>
+            `<li class="news-list__navbar__category" data-selected=${index === categoryIndex ? "yes" : "no"}>${category}</li>`
+        ).join("")
     }
 }
 

--- a/src/renderers/CategoryRenderer.js
+++ b/src/renderers/CategoryRenderer.js
@@ -18,14 +18,14 @@ class CategoryRenderer extends Renderer {
      * @param {string} event.eventName - 이벤트의 이름 
      * @returns 
      */
-    checkEventName(event) {
+    _checkEventName(event) {
         return event.eventName === 'clickCategory';
     }
 
     /**
      * 렌더 함수
      */
-    render({ eventName, value, ...rest }) {
+    _render({ eventName, value, ...rest }) {
         const categoryListElement = this.#generateCategoryListElement(value);
         this.categoryContainer.innerHTML = '';
         this.categoryContainer.innerHTML += categoryListElement;

--- a/src/renderers/CategoryRenderer.js
+++ b/src/renderers/CategoryRenderer.js
@@ -16,7 +16,7 @@ class CategoryRenderer extends Renderer {
     /**
      * 이 클래스에서 실행 될 이벤트인지 확인한다.
      * @param {string} event.eventName - 이벤트의 이름 
-     * @returns 
+     * @returns {boolean}
      */
     _checkEventName(event) {
         return event.eventName === 'clickCategory'; // 나중에 상수 배열로 빼기
@@ -24,7 +24,6 @@ class CategoryRenderer extends Renderer {
 
     /**
      * 생성된 element를 렌더링하는 함수
-     * @param {object} categoryInfo - 카테고리 정보
      * @param {number} categoryIndex - 선택된 카테고리 인덱스
      * @param {Array} categoryList - 표시 될 카테고리 목록
      */

--- a/src/renderers/Renderer.js
+++ b/src/renderers/Renderer.js
@@ -15,20 +15,20 @@ class Renderer {
      * @param {*} event.value - 렌더 함수에 전달할 값 
      */
     update(event) {
-        if (this.checkEventName(event)) this.render(event);
+        if (this._checkEventName(event)) this._render(event);
     }
 
     /**
      * @throws {Error} - 미구현 시 오류 발생
      */
-    checkEventName() {
+    _checkEventName() {
         throw new Error(ERROR_MESSAGE.NOT_IMPLEMENTED);
     }
 
     /**
      * @throws {Error} - 미구현 시 오류 발생
      */
-    render() {
+    _render() {
         throw new Error(ERROR_MESSAGE.NOT_IMPLEMENTED);
     }
 }

--- a/src/renderers/SubAllRenderer.js
+++ b/src/renderers/SubAllRenderer.js
@@ -1,0 +1,49 @@
+import { subAllEventNameList } from "../events/subAllEvent.js";
+import { Renderer } from "./Renderer.js";
+
+/**
+ * @class SubAllRenderer
+ * @classdesc '전체언론사', '내가 구독한 언론사' 중 선택한 정보를 렌더링하는 클래스
+ */
+class SubAllRenderer extends Renderer {
+    /**
+     * @constructor
+     */
+    constructor() {
+        super();
+        this.subAllContainer = document.querySelector(".news-list__menu__selectors");
+    }
+
+    /**
+     * 이 클래스에서 실행 될 이벤트인지 확인한다.
+     * @param {string} event.eventName - 이벤트의 이름
+     * @returns {boolean}
+     */
+    _checkEventName(event) {
+        return subAllEventNameList.includes(event.eventName);
+    }
+
+    /**
+     * 생성된 element를 렌더링 하는 함수
+     * @param {string} subAllInfo - 선택된 '전체언론사', '내가 구독한 언론사' 정보 
+     */
+    _render({ subAllInfo }) {
+        debugger;
+        const subAllElement = this.#generateSubAllElement(subAllInfo);
+        this.subAllContainer.innerHTML = '';
+        this.subAllContainer.innerHTML += subAllElement;
+    }
+
+    /**
+     * 표시될 element를 생성하는 함수
+     * @param {string} subAllInfo - 선택된 '전체언론사', '내가 구독한 언론사' 정보 
+     * @returns {Element}
+     */
+    #generateSubAllElement(subAllInfo) {
+        debugger;
+        return `<span class="news-list__menu__selectors__all" ${subAllInfo === "all" ? "data-selected='yes'" : ""}>전체언론사</span>
+                <span class="news-list__menu__selectors__all" ${subAllInfo === "sub" ? "data-selected='yes'" : ""}>내가 구독한 언론사</span>`
+    }
+}
+
+export { SubAllRenderer }

--- a/src/states/NewsStates.js
+++ b/src/states/NewsStates.js
@@ -32,9 +32,9 @@ class NewsStates extends States {
         this.categoryIndex = value;
         this.notify({
             eventName: "clickCategory",
-            value: this.categoryIndex,
+            categoryIndex: this.categoryIndex,
+            categoryList: this.allSubInfo === "all" ? Object.keys(this.allNewsData) : Object.keys(this.subscribedNewsData)
         })
-        console.log(this.subscribedNewsData)
     }
 }
 

--- a/src/states/NewsStates.js
+++ b/src/states/NewsStates.js
@@ -11,15 +11,17 @@ class NewsStates extends States {
      * @param {number} newsInfo.categoryIndex - 어떤 카테고리가 선택되어 있는지에 대한 정보 
      * @param {string} newsInfo.allSubInfo - 구독 언론사인지, 전체 언론사인지에 대한 정보 
      * @param {number} newsInfo.newsListIndex - 몇 번째 뉴스 목록인지 대한 정보 
-     * @param {json} newsInfo.newsList - 뉴스 목록에 대한 json 파일
+     * @param {json} newsInfo.allNewsData - 전체 언론사 목록에 대한 json 파일
+     * @param {json} newsInfo.subscribedNewsData - 구독한 언론사 목록에 대한 json 파일
      * @param {Renderer} renderers - 렌더링을 해주는 클래스
      */
-    constructor({ categoryIndex = 0, allSubInfo = 'all', newsListIndex = 0, newsList }) {
+    constructor({ categoryIndex = 0, allSubInfo = 'all', newsListIndex = 0, allNewsData, subscribedNewsData }) {
         super();
         this.categoryIndex = categoryIndex;
         this.allSubInfo = allSubInfo;
         this.newsListIndex = newsListIndex;
-        this.newsList = newsList;
+        this.allNewsData = allNewsData;
+        this.subscribedNewsData = subscribedNewsData;
     }
 
     /**
@@ -30,8 +32,9 @@ class NewsStates extends States {
         this.categoryIndex = value;
         this.notify({
             eventName: "clickCategory",
-            value: this.categoryIndex
+            value: this.categoryIndex,
         })
+        console.log(this.subscribedNewsData)
     }
 }
 

--- a/src/states/NewsStates.js
+++ b/src/states/NewsStates.js
@@ -9,16 +9,16 @@ class NewsStates extends States {
      * 
      * @param {Object} newsInfo - 뉴스 정보를 받아오는 객체
      * @param {number} newsInfo.categoryIndex - 어떤 카테고리가 선택되어 있는지에 대한 정보 
-     * @param {string} newsInfo.allSubInfo - 구독 언론사인지, 전체 언론사인지에 대한 정보 
+     * @param {string} newsInfo.subAllInfo - 구독 언론사인지, 전체 언론사인지에 대한 정보 
      * @param {number} newsInfo.newsListIndex - 몇 번째 뉴스 목록인지 대한 정보 
      * @param {json} newsInfo.allNewsData - 전체 언론사 목록에 대한 json 파일
      * @param {json} newsInfo.subscribedNewsData - 구독한 언론사 목록에 대한 json 파일
      * @param {Renderer} renderers - 렌더링을 해주는 클래스
      */
-    constructor({ categoryIndex = 0, allSubInfo = 'all', newsListIndex = 0, allNewsData, subscribedNewsData }) {
+    constructor({ categoryIndex = 0, subAllInfo = 'all', newsListIndex = 0, allNewsData, subscribedNewsData }) {
         super();
         this.categoryIndex = categoryIndex;
-        this.allSubInfo = allSubInfo;
+        this.subAllInfo = subAllInfo;
         this.newsListIndex = newsListIndex;
         this.allNewsData = allNewsData;
         this.subscribedNewsData = subscribedNewsData;
@@ -33,7 +33,19 @@ class NewsStates extends States {
         this.notify({
             eventName: "clickCategory",
             categoryIndex: this.categoryIndex,
-            categoryList: this.allSubInfo === "all" ? Object.keys(this.allNewsData) : Object.keys(this.subscribedNewsData)
+            categoryList: this.subAllInfo === "all" ? Object.keys(this.allNewsData) : Object.keys(this.subscribedNewsData)
+        })
+    }
+
+    /**
+     * '전체언론사', '내가 구독한 언론사'를 설정하는 함수, 지금 Subject를 구독하고 있는 Observer에게 알림을 전달
+     * @param {string} value - 선택된 '전체언론사', '내가 구독한 언론사'정보 
+     */
+    setSubAll(value) {
+        this.subAllInfo = value === 0 ? "all" : "sub";
+        this.notify({
+            eventName: "clickSubAll",
+            subAllInfo: this.subAllInfo
         })
     }
 }

--- a/src/states/States.js
+++ b/src/states/States.js
@@ -24,8 +24,8 @@ class States {
      * @param {string} event.eventName - 발생한 이벤트 정보 이름
      * @param {*} event.value - 렌더 함수에 전달할 값 
      */
-    notify(event) {
-        this.observers.forEach((observer) => observer.update(event))
+    notify(eventInfo) {
+        this.observers.forEach((observer) => observer.update(eventInfo))
     }
 }
 

--- a/src/utils/deepFreeze.js
+++ b/src/utils/deepFreeze.js
@@ -1,3 +1,8 @@
+/**
+ * 객체를 deep freeze 하는 함수
+ * @param {*} target - 동결할 대상
+ * @returns 동결한 객체
+ */
 export function deepFreeze(target) {
     if (target && typeof target === "object" && !Object.isFrozen(target)) {
         Object.freeze(target);

--- a/src/utils/deepFreeze.js
+++ b/src/utils/deepFreeze.js
@@ -1,0 +1,8 @@
+export function deepFreeze(target) {
+    if (target && typeof target === "object" && !Object.isFrozen(target)) {
+        Object.freeze(target);
+        Object.keys(target).forEach(key => deepFreeze(target[key]));
+    }
+
+    return target;
+}


### PR DESCRIPTION
## 설계
---
먼저 설계 부터 다 하고 코드를 작성해보고 싶었지만, 저의 능력의 한계로 인해 먼저 카테고리 선택 기능만 설계와 구현을 병행해보았습니다. 설계를 하다 막히면 코드를 짜보고 코드를 짜보다 다시 구현을 하는 과정을 반복하면서 다음과 같은 그림을 완성했습니다. 
<img width="1084" alt="스크린샷 2024-07-10 오후 6 17 46" src="https://github.com/softeerbootcamp4th/fe-newsstand/assets/76507017/fc16554d-3d2c-48cc-9304-24e6d142d406">
<img width="948" alt="스크린샷 2024-07-10 오후 6 18 16" src="https://github.com/softeerbootcamp4th/fe-newsstand/assets/76507017/0a883e86-0ffd-4daf-b781-afb22a01a9fa">
NewsState가 Subject가 되고, Categoryrenderer가 Observer가 됩니다.
CategoryEventHandler는 이벤트를 외부에서 주입받아 이벤트를 등록하는 역할을 합니다.
#### 등록된 이벤트에서 NewsState의 state를 변경하는 setState함수를 호출하면, NewsState에서 notify가 실행되어 Renderer에게 알리면 render가 실행되는 구조입니다. 
사실 이렇게 짜놓고 이전 코드와 장점이 명확하게 보이지는 않아서 내일은 이 코드의 장점을 찾아보고 정리하는 시간을 좀 가져보려 합니다. 

## 이벤트 구현 분리
원래는 EventHandler를 구현한 클래스에 필요한 이벤트의 콜백 함수 들을 모두 구현해 놓고 사용하려 했습니다. 하지만, 이벤트가 너무 많아지면 클래스가 너무 무거워질 것 같아서 밖에서 이벤트의 콜백 함수를 주입해 주기로 하였습니다. 이벤트를 추가하려면 이벤트 함수를 작성하고 EventHandler에 주입하기만 하면 됩니다. 이렇게 하면 EventHandler는 각 이벤트의 구체적인 정보를 알 필요가 없다는 장점이 있는 것 같습니다.(???)

## 설계 먼저
카테고리 기능에 대해 구현과 설계를 동시에 진행한 후, '전체언론사', '내가 구독한 언론사' 선택 기능을 구현할 때는 설계를 먼저 하고 구현에 들어갔습니다. 
<img width="995" alt="스크린샷 2024-07-10 오후 5 12 23" src="https://github.com/softeerbootcamp4th/fe-newsstand/assets/76507017/cbcd48d2-32fa-4176-af28-3ff0dedb2312">

<img width="1153" alt="스크린샷 2024-07-10 오후 5 18 00" src="https://github.com/softeerbootcamp4th/fe-newsstand/assets/76507017/d4a0c140-08ce-4497-8c6e-597e0d1904df">
이렇게 함수 이름, 매개변수, 반환 값 등을 먼저 설계하고 코딩을 하니 조금 더 코드를 작성하기 쉬웠던 것 같습니다. 