### PR TITLE
07/11-마경미-글로벌 스테이트 추가, MVC 패턴 적용

### DIFF
--- a/newsstand/data/tabNewsData.js
+++ b/newsstand/data/tabNewsData.js
@@ -99,7 +99,7 @@
                 mediaName: "SBSBiz",
                 sourceLogo: "assets/news/logo/sbsBiz.svg",
                 newsDate: "2023.02.10. 11:11",
-                subscribe: "Y",
+                subscribe: "N",
                 mainNews: {
                   thumbnailImage:
                     "https://img.sbs.co.kr/newimg/news/20240706/201954883_1280.jpg",
@@ -192,7 +192,7 @@
                 mediaName: "연합뉴스TV",
                 sourceLogo: "assets/news/logo/yonhap.svg",
                 newsDate: "2023.02.10. 18:27",
-                subscribe: "Y",
+                subscribe: "N",
                 mainNews: {
                   thumbnailImage:
                     "https://img0.yna.co.kr/photo/yna/YH/2024/01/04/PYH2024010414600001300_P4.jpg",
@@ -234,7 +234,7 @@
                 mediaName: "세계일보",
                 sourceLogo: "assets/news/logo/segye.svg",
                 newsDate: "2023.02.10. 11:11",
-                subscribe: "Y",
+                subscribe: "N",
                 mainNews: {
                   thumbnailImage:
                     "https://img.segye.com/content/image/2024/07/05/20240705508906.jpg",
@@ -284,7 +284,7 @@
                 mediaName: "조선일보",
                 sourceLogo: "assets/news/logo/chosun.svg",
                 newsDate: "2023.12.10. 11:27",
-                subscribe: "Y",
+                subscribe: "N",
                 mainNews: {
                   thumbnailImage:
                     "https://imgnews.pstatic.net/image/023/2024/07/06/0003844628_001_20240706160012847.jpg?type=w647",
@@ -379,7 +379,7 @@
                 mediaName: "서울신문",
                 sourceLogo: "assets/news/logo/seoul.svg",
                 newsDate: "2023.04.15. 18:27",
-                subscribe: "Y",
+                subscribe: "N",
                 mainNews: {
                   thumbnailImage:
                     "https://imgnews.pstatic.net/image/081/2024/07/06/0003462874_001_20240706213311195.jpg",
@@ -424,7 +424,7 @@
                 mediaName: "한겨레",
                 sourceLogo: "assets/news/logo/hankyoreh.svg",
                 newsDate: "2024.04.10. 18:27",
-                subscribe: "Y",
+                subscribe: "N",
                 mainNews: {
                   thumbnailImage:
                     "https://imgnews.pstatic.net/image/028/2024/07/05/0002696883_001_20240706181017816.jpg",
@@ -518,7 +518,7 @@
                 mediaName: "국민일보",
                 sourceLogo: "assets/news/logo/kookmin.svg",
                 newsDate: "2024.10.30. 18:27",
-                subscribe: "Y",
+                subscribe: "N",
                 mainNews: {
                   thumbnailImage:
                     "https://imgnews.pstatic.net/image/005/2024/07/06/2024070605322412876_1720211544_0020279245_20240706064407477.jpg",
@@ -567,7 +567,7 @@
                 mediaName: "데일리안",
                 sourceLogo: "assets/news/logo/dailyan.svg",
                 newsDate: "2022.02.22. 18:27",
-                subscribe: "Y",
+                subscribe: "N",
                 mainNews: {
                   thumbnailImage:
                     "https://cdnimage.dailian.co.kr/news/202407/news_1720067848_1379800_m_1.jpeg",
@@ -610,7 +610,7 @@
                 mediaName: "아이뉴스",
                 sourceLogo: "assets/news/logo/inews.svg",
                 newsDate: "2021.01.11. 11:07",
-                subscribe: "Y",
+                subscribe: "N",
                 mainNews: {
                   thumbnailImage:
                     "https://image.inews24.com/v1/d78daaadfcbb27.jpg",
@@ -701,7 +701,7 @@
                 mediaName: "아시아경제",
                 sourceLogo: "assets/news/logo/asia.svg",
                 newsDate: "2020.02.20. 18:27",
-                subscribe: "Y",
+                subscribe: "N",
                 mainNews: {
                   thumbnailImage:
                     "https://cphoto.asiae.co.kr/listimglink/1/2024070617161542351_1720253775.jpg",

--- a/newsstand/src/app/App.js
+++ b/newsstand/src/app/App.js
@@ -1,6 +1,7 @@
 import HeaderContainer from "../views/header/headerContainer.js";
 import Headline from "../views/headline/headline.js";
-import Main from "../views/main/main.js";
+// import Main from "../views/main/main.js";
+import MainController from "../views/main/mainController.js";
 
 export const App = () => {
     const appContainer = document.createElement('div');
@@ -50,8 +51,11 @@ export const App = () => {
             return;
         }
 
-        const main = Main();
-        mainContainer.appendChild(main.element);
+        // const main = Main();
+        // mainContainer.appendChild(main.element);
+
+        const mainViewController = new MainController();
+        mainContainer.appendChild(mainViewController.getElement()); 
     }
 
     function render() {

--- a/newsstand/src/app/GlobalState.js
+++ b/newsstand/src/app/GlobalState.js
@@ -1,0 +1,49 @@
+import DataManager from "../manager/dataManager.js";
+
+class GlobalState {
+    constructor() {
+        this.state = {
+            isAllPress: true,
+            isGridView: true,
+            tabFields: DataManager.getAllPressTabs(),
+            selectedCategoryIndex: 0,
+            selectedCategoryCountIndex: 0
+        };
+        this.listeners = {};
+    }
+
+    getState(key) {
+        return this.state[key];
+    }
+
+    setState(key, value) {
+        this.state[key] = value;
+        this.notifyListeners(key, value);
+    }
+
+    subscribe(key, listener) {
+        if (!this.listeners[key]) {
+            this.listeners[key] = [];
+        }
+        this.listeners[key].push(listener);
+    }
+
+    unsubscribe(key, listener) {
+        if (!this.listeners[key]) return;
+
+        const index = this.listeners[key].indexOf(listener);
+        if (index > -1) {
+            this.listeners[key].splice(index, 1);
+        }
+    }
+
+    notifyListeners(key, value) {
+        if (!this.listeners[key]) return;
+        this.listeners[key].forEach(listener => {
+            listener(value)
+        });
+    }
+}
+
+const globalState = new GlobalState();
+export default globalState;

--- a/newsstand/src/components/snackBar/snackBar.js
+++ b/newsstand/src/components/snackBar/snackBar.js
@@ -24,6 +24,9 @@ export const SnackBar = (props) => {
 
       setTimeout(() => {
           document.body.removeChild(element);
+          if (props.callback) {
+            props.callback();
+        }
       }, 3600);
   }
 

--- a/newsstand/src/manager/dataManager.js
+++ b/newsstand/src/manager/dataManager.js
@@ -1,0 +1,59 @@
+import TAB_NEWS_DATA from "../../data/tabNewsData.js";
+
+export const DataManager = {
+  getAllPressTabs() {
+    return TAB_NEWS_DATA.data.flatMap(tab => {
+      return tab.newsTabs.map(newsTab => {
+        return {
+          tabName: newsTab.tabName,
+          tabData: newsTab.tabData
+        };
+      });
+    });
+  },
+
+  getSubscribedPressTabs() {
+    const tabs = this.getAllPressTabs()
+    const subscribedPressTabsString = localStorage.getItem("subscribed");
+
+    if (!subscribedPressTabsString) {
+      console.log("no subscribed press");
+      return [];
+    }
+
+    try {
+      const subscribedPressTabs = subscribedPressTabsString.split(',');
+      const newTabs = [];
+
+      tabs.forEach(tab => {
+        const filteredTabData = tab.tabData.filter(data => {
+          return subscribedPressTabs.includes(data.mediaName.trim());
+        });
+
+        if (filteredTabData.length > 0) {
+          filteredTabData.forEach(data => {
+            const newTab = {
+              tabName: data.mediaName,
+              tabData: [{
+                mediaName: data.mediaName,
+                sourceLogo: data.sourceLogo,
+                newsDate: data.newsDate,
+                subscribe: 'Y',
+                mainNews: data.mainNews,
+                subNews: data.subNews
+              }]
+            };
+            newTabs.push(newTab);
+          });
+        }
+      });
+
+      return newTabs;
+    } catch (error) {
+      console.error("Error parsing subscribed press tabs:", error);
+      return [];
+    }
+  }
+};
+
+export default DataManager;

--- a/newsstand/src/manager/dataManager.js
+++ b/newsstand/src/manager/dataManager.js
@@ -1,20 +1,32 @@
 import TAB_NEWS_DATA from "../../data/tabNewsData.js";
+import { StorageKey } from "../namespace/StorageKey.js";
+import storageManager from "./localStorageManager.js";
 
 export const DataManager = {
   getAllPressTabs() {
+    const subscribedPressTabsString = storageManager.getStorage(StorageKey.SUBSCRIBED);
+    const subscribedPressTabs = subscribedPressTabsString ? subscribedPressTabsString.split(',') : [];
+
     return TAB_NEWS_DATA.data.flatMap(tab => {
       return tab.newsTabs.map(newsTab => {
+        const updatedTabData = newsTab.tabData.map(data => {
+          return {
+            ...data,
+            subscribe: subscribedPressTabs.includes(data.mediaName.trim()) ? 'Y' : 'N'
+          };
+        });
+
         return {
           tabName: newsTab.tabName,
-          tabData: newsTab.tabData
+          tabData: updatedTabData
         };
       });
     });
   },
 
   getSubscribedPressTabs() {
-    const tabs = this.getAllPressTabs()
-    const subscribedPressTabsString = localStorage.getItem("subscribed");
+    const tabs = this.getAllPressTabs();
+    const subscribedPressTabsString = storageManager.getStorage(StorageKey.SUBSCRIBED);
 
     if (!subscribedPressTabsString) {
       console.log("no subscribed press");

--- a/newsstand/src/manager/intervalManager.js
+++ b/newsstand/src/manager/intervalManager.js
@@ -1,27 +1,27 @@
 const intervalManager = {
-    timers: {}, // 타이머를 저장할 객체
+    timers: {},
 
     startTimer: (key, callback, interval) => {
         if (intervalManager.timers[key]) {
-            clearInterval(intervalManager.timers[key].ref); // 이미 있는 타이머 중지
+            clearInterval(intervalManager.timers[key].ref);
         }
         intervalManager.timers[key] = {
-            ref: setInterval(callback, interval) // 새로운 타이머 시작
+            ref: setInterval(callback, interval)
         };
     },
 
     stopTimer: (key) => {
         if (intervalManager.timers[key]) {
-            clearInterval(intervalManager.timers[key].ref); // 타이머 중지
-            delete intervalManager.timers[key]; // 객체에서 제거
+            clearInterval(intervalManager.timers[key].ref);
+            delete intervalManager.timers[key];
         }
     },
 
     stopAllTimers: () => {
         for (let key in intervalManager.timers) {
-            clearInterval(intervalManager.timers[key].ref); // 모든 타이머 중지
+            clearInterval(intervalManager.timers[key].ref);
         }
-        intervalManager.timers = {}; // 객체 초기화
+        intervalManager.timers = {};
     }
 };
 

--- a/newsstand/src/manager/localStorageManager.js
+++ b/newsstand/src/manager/localStorageManager.js
@@ -1,0 +1,29 @@
+import { StorageKey } from "../namespace/StorageKey.js";
+
+const storageManager = {
+    getStorage: (key) => {
+        return localStorage.getItem(key)
+    },
+
+    setStorage: (key, value) => {
+        if (key == StorageKey.SUBSCRIBED) {
+            value = storageManager.makeNewSubscribeList(key, value);
+        }
+
+        localStorage.setItem(key, value)
+    },
+
+    makeNewSubscribeList: (key, value) => {
+        let subscribedPress = storageManager.getStorage(key);
+
+        let subscribedSet = new Set();
+        if (subscribedPress) {
+            subscribedSet = new Set(subscribedPress.split(","));
+        }
+        subscribedSet.add(value);
+
+        return Array.from(subscribedSet).join(",")
+    }
+};
+
+export default storageManager;

--- a/newsstand/src/namespace/IntervalKey.js
+++ b/newsstand/src/namespace/IntervalKey.js
@@ -1,10 +1,10 @@
 export const IntervalKey = Object.freeze({
-    RollingLeft: 'RollingLeft',
-    RollingRight: 'RollingRight',
-    Progress: 'Progress'
+    ROLLINGl_LEFT: 'RollingLeft',
+    ROLLING_RIGHT: 'RollingRight',
+    PROGRESS: 'Progress'
 });
 
 export const IntervalConst = Object.freeze({
-    RollingTime: 2000,
-    ProgressTime: 20000
+    ROLLING_TIME: 2000,
+    PROGRESS_TIME: 20000
 })

--- a/newsstand/src/namespace/StateKey.js
+++ b/newsstand/src/namespace/StateKey.js
@@ -1,7 +1,7 @@
 export const StateKey = Object.freeze({
-    isAllPress: 'isAllPress',
-    tabFields: 'tabFields',
-    isGridView: 'isGridView',
-    selectedCategoryIndex: 'selectedCategoryIndex',
-    selectedCategoryCountIndex: 'selectedCategoryCountIndex'
+    IS_ALLPRESS: 'isAllPress',
+    TABFIELDS: 'tabFields',
+    IS_GRIDVIEW: 'isGridView',
+    SELECTED_CATEGORY_INDEX: 'selectedCategoryIndex',
+    SELECTED_CATEGORY_COUNT_INDEX: 'selectedCategoryCountIndex'
 });

--- a/newsstand/src/namespace/StateKey.js
+++ b/newsstand/src/namespace/StateKey.js
@@ -1,0 +1,7 @@
+export const StateKey = Object.freeze({
+    isAllPress: 'isAllPress',
+    tabFields: 'tabFields',
+    isGridView: 'isGridView',
+    selectedCategoryIndex: 'selectedCategoryIndex',
+    selectedCategoryCountIndex: 'selectedCategoryCountIndex'
+});

--- a/newsstand/src/namespace/StorageKey.js
+++ b/newsstand/src/namespace/StorageKey.js
@@ -1,0 +1,3 @@
+export const StorageKey = Object.freeze({
+    SUBSCRIBED: 'subscribed'
+});

--- a/newsstand/src/views/headline/headline.js
+++ b/newsstand/src/views/headline/headline.js
@@ -55,12 +55,12 @@ export const Headline = () => {
     };
 
     function startLeftRolling() {
-        intervalManager.startTimer(IntervalKey.RollingLeft, rollLeftNews, IntervalConst.RollingTime);
+        intervalManager.startTimer(IntervalKey.ROLLINGl_LEFT, rollLeftNews, IntervalConst.ROLLING_TIME);
     }
 
     function startRightRolling() {
         setTimeout(() => {
-            intervalManager.startTimer(IntervalKey.RollingRight, rollRightNews, IntervalConst.RollingTime);
+            intervalManager.startTimer(IntervalKey.ROLLING_RIGHT, rollRightNews, IntervalConst.ROLLING_TIME);
         }, 1000); 
     }
 

--- a/newsstand/src/views/main/mainController.js
+++ b/newsstand/src/views/main/mainController.js
@@ -1,0 +1,45 @@
+import MainModel from "./mainModel.js";
+import MainView from "./mainView.js";
+import PressMenuController from "../pressMenu/pressMenuController.js";
+import NewsListController from "../newsList/NewsListController.js";
+
+export class MainController {
+  constructor() {
+    this.model = new MainModel();
+    this.view = new MainView();
+    this.pressMenuController = new PressMenuController();
+    this.newsListController = new NewsListController();
+
+    this.view.render(
+      this.pressMenuController.getElement(),
+      this.newsListController.getElement()
+    );
+  }
+
+  handleToggleAllPress(newValue) {
+    this.model.setAllPress(newValue);
+    this.updateNewsList();
+  }
+
+  handleToggleListView(newValue) {
+    this.model.setListView(newValue);
+    this.updateNewsList();
+  }
+
+  updateNewsList() {
+    this.newsListController = new NewsListController({
+      isAllPress: this.model.getState().isAllPress,
+      tabs: this.model.createTabs(),
+    });
+    this.view.render(
+      this.pressMenuController.getElement(),
+      this.newsListController.getElement()
+    );
+  }
+
+  getElement() {
+    return this.view.getElement();
+  }
+}
+
+export default MainController;

--- a/newsstand/src/views/main/mainModel.js
+++ b/newsstand/src/views/main/mainModel.js
@@ -1,75 +1,11 @@
 import TAB_NEWS_DATA from "../../../data/tabNewsData.js";
+import storageManager from "../../manager/localStorageManager.js";
+import { StorageKey } from "../../namespace/StorageKey.js";
 
 export default class MainModel {
   constructor() {
     this.isAllPress = true;
     this.isList = true;
-  }
-
-  createTabs() {
-    let tabs = this.getAllPressTabs();
-    let subscribedPress = this.getSubscribedPressTabs(tabs);
-
-    tabs = this.isAllPress ? tabs : subscribedPress;
-    return tabs;
-  }
-
-  getAllPressTabs() {
-    const tabDataWithCounts = TAB_NEWS_DATA.data.flatMap((tab) => {
-      return tab.newsTabs.map((newsTab) => {
-        return {
-          tabName: newsTab.tabName,
-          tabData: newsTab.tabData,
-        };
-      });
-    });
-
-    return tabDataWithCounts;
-  }
-
-  // 데이터 매니저 따로 빼기
-  getSubscribedPressTabs(tabs) {
-    const subscribedPressTabsString = localStorage.getItem("subscribed");
-
-    if (!subscribedPressTabsString) {
-      console.log("no subscribed press");
-      return [];
-    }
-
-    try {
-      const subscribedPressTabs = subscribedPressTabsString.split(",");
-      const newTabs = [];
-
-      tabs.forEach((tab) => {
-        const filteredTabData = tab.tabData.filter((data) => {
-          return subscribedPressTabs.includes(data.mediaName.trim());
-        });
-
-        if (filteredTabData.length > 0) {
-          filteredTabData.forEach((data) => {
-            const newTab = {
-              tabName: data.mediaName,
-              tabData: [
-                {
-                  mediaName: data.mediaName,
-                  sourceLogo: data.sourceLogo,
-                  newsDate: data.newsDate,
-                  subscribe: "Y",
-                  mainNews: data.mainNews,
-                  subNews: data.subNews,
-                },
-              ],
-            };
-            newTabs.push(newTab);
-          });
-        }
-      });
-
-      return newTabs;
-    } catch (error) {
-      console.error("Error parsing subscribed press tabs:", error);
-      return [];
-    }
   }
 
   setAllPress(newValue) {

--- a/newsstand/src/views/main/mainModel.js
+++ b/newsstand/src/views/main/mainModel.js
@@ -1,0 +1,89 @@
+import TAB_NEWS_DATA from "../../../data/tabNewsData.js";
+
+export default class MainModel {
+  constructor() {
+    this.isAllPress = true;
+    this.isList = true;
+  }
+
+  createTabs() {
+    let tabs = this.getAllPressTabs();
+    let subscribedPress = this.getSubscribedPressTabs(tabs);
+
+    tabs = this.isAllPress ? tabs : subscribedPress;
+    return tabs;
+  }
+
+  getAllPressTabs() {
+    const tabDataWithCounts = TAB_NEWS_DATA.data.flatMap((tab) => {
+      return tab.newsTabs.map((newsTab) => {
+        return {
+          tabName: newsTab.tabName,
+          tabData: newsTab.tabData,
+        };
+      });
+    });
+
+    return tabDataWithCounts;
+  }
+
+  // 데이터 매니저 따로 빼기
+  getSubscribedPressTabs(tabs) {
+    const subscribedPressTabsString = localStorage.getItem("subscribed");
+
+    if (!subscribedPressTabsString) {
+      console.log("no subscribed press");
+      return [];
+    }
+
+    try {
+      const subscribedPressTabs = subscribedPressTabsString.split(",");
+      const newTabs = [];
+
+      tabs.forEach((tab) => {
+        const filteredTabData = tab.tabData.filter((data) => {
+          return subscribedPressTabs.includes(data.mediaName.trim());
+        });
+
+        if (filteredTabData.length > 0) {
+          filteredTabData.forEach((data) => {
+            const newTab = {
+              tabName: data.mediaName,
+              tabData: [
+                {
+                  mediaName: data.mediaName,
+                  sourceLogo: data.sourceLogo,
+                  newsDate: data.newsDate,
+                  subscribe: "Y",
+                  mainNews: data.mainNews,
+                  subNews: data.subNews,
+                },
+              ],
+            };
+            newTabs.push(newTab);
+          });
+        }
+      });
+
+      return newTabs;
+    } catch (error) {
+      console.error("Error parsing subscribed press tabs:", error);
+      return [];
+    }
+  }
+
+  setAllPress(newValue) {
+    this.isAllPress = newValue;
+  }
+
+  setListView(newValue) {
+    this.isList = newValue;
+  }
+
+  getState() {
+    return {
+      isAllPress: this.isAllPress,
+      isList: this.isList,
+    };
+  }
+}

--- a/newsstand/src/views/main/mainView.js
+++ b/newsstand/src/views/main/mainView.js
@@ -1,0 +1,21 @@
+export default class MainView {
+    constructor() {
+      this.element = document.createElement("div");
+      this.element.className = "main-container";
+      this.contentContainer = document.createElement("div");
+      this.contentContainer.className = "main-content-container";
+    }
+  
+    render(pressMenuElement, newsListElement) {
+      this.element.innerHTML = "";
+      this.element.appendChild(pressMenuElement);
+      this.element.appendChild(this.contentContainer);
+      this.contentContainer.innerHTML = "";
+      this.contentContainer.appendChild(newsListElement);
+    }
+  
+    getElement() {
+      return this.element;
+    }
+  }
+  

--- a/newsstand/src/views/newsList/newsList.js
+++ b/newsstand/src/views/newsList/newsList.js
@@ -12,7 +12,7 @@ export const NewsList = ({ isAllPress, tabs }) => {
     let selectedPressIndex = 0;
 
     function startTimer() {
-        intervalManager.startTimer(IntervalKey.Progress,changeToNextPress, IntervalConst.ProgressTime)
+        intervalManager.startTimer(IntervalKey.PROGRESS,changeToNextPress, IntervalConst.PROGRESS_TIME);
     }
 
     function render() {

--- a/newsstand/src/views/newsList/newsListController.js
+++ b/newsstand/src/views/newsList/newsListController.js
@@ -1,75 +1,81 @@
-import NewsListModel from './newsListModel.js';
-import NewsListView from './newsListView.js';
+import NewsListModel from "./newsListModel.js";
+import NewsListView from "./newsListView.js";
 
-import PressCategoryController from './pressCategory/pressCategoryController.js';
-import PressInfoController from './pressInfo/pressInfoController.js';
-import PressNewsController from './pressNews/pressNewsController.js';
+import PressCategoryController from "./pressCategory/pressCategoryController.js";
+import PressInfoController from "./pressInfo/pressInfoController.js";
+import PressNewsController from "./pressNews/pressNewsController.js";
 
-import intervalManager from '../../manager/intervalManager.js';
-import { IntervalKey, IntervalConst } from '../../namespace/intervalKey.js';
-import globalState from '../../app/GlobalState.js';
-import { StateKey } from '../../namespace/StateKey.js';
-import DataManager from '../../manager/dataManager.js';
+import intervalManager from "../../manager/intervalManager.js";
+import { IntervalKey, IntervalConst } from "../../namespace/intervalKey.js";
+import globalState from "../../app/GlobalState.js";
+import { StateKey } from "../../namespace/StateKey.js";
 
 class NewsListController {
-    constructor() {
-        this.model = new NewsListModel();
-        this.view = new NewsListView();
+  constructor() {
+    this.model = new NewsListModel();
+    this.view = new NewsListView({ onClickArrowButton: (value) => this.handleArrowButtonClick(value)});
 
-        this.pressCategoryController = new PressCategoryController();
-        this.pressInfoController = new PressInfoController();
-        this.pressNewsController = new PressNewsController();
+    this.pressCategoryController = new PressCategoryController();
+    this.pressInfoController = new PressInfoController();
+    this.pressNewsController = new PressNewsController();
 
-        this.view.render(
-            this.pressCategoryController.getElement(),
-            this.pressInfoController.getElement(),
-            this.pressNewsController.getElement()
-        );
+    this.view.render(
+      this.pressCategoryController.getElement(),
+      this.pressInfoController.getElement(),
+      this.pressNewsController.getElement()
+    );
 
-        globalState.subscribe(StateKey.tabFields, (value) => this.updateModel(value))
-        // globalState.subscribe(StateKey.isAllPress, this.updateModel) => 안됨
-        this.updateModel()
+    globalState.subscribe(StateKey.TABFIELDS, (value) =>
+      this.updateModel(StateKey.TABFIELDS, value)
+    );
+    globalState.subscribe(StateKey.SELECTED_CATEGORY_INDEX, (value) =>
+      this.updateModel(StateKey.SELECTED_CATEGORY_INDEX, value)
+    );
+    globalState.subscribe(StateKey.SELECTED_CATEGORY_COUNT_INDEX, (value) =>
+      this.updateModel(StateKey.SELECTED_CATEGORY_COUNT_INDEX, value)
+    );
 
-        intervalManager.startTimer(IntervalKey.Progress, this.changeToNextPress.bind(this), IntervalConst.ProgressTime);
+    this.updateModel();
 
-        this.view.addEventListenerToArrowButton(this.handleArrowButtonClick.bind(this));
+    intervalManager.startTimer(IntervalKey.PROGRESS, () => this.handleArrowButtonClick("next"), IntervalConst.PROGRESS_TIME)
+  }
+
+  changeToNextPress() {
+    this.model.moveNextPress();
+  }
+
+  changeToPrevPress() {
+    this.model.movePrevPress();
+  }
+
+  handleArrowButtonClick(direction) {
+    if (direction === "prev") {
+      this.changeToPrevPress();
+    } else if (direction === "next") {
+      this.changeToNextPress();
+    }
+  }
+
+  updateModel(key, value) {
+    if (key) {
+      this.model.setState({ [key]: value });
     }
 
-    handleChangeCategory(index) {
-        this.model.updateSelectedCategory(index);
-    }
+    const newState = this.model.getState();
+    this.view.update(newState);
+  }
 
-    changeToNextPress() {
-        this.model.moveNextPress();
-    }
+  render() {
+    this.view.render(
+      this.pressCategoryController.getElement(),
+      this.pressInfoController.getElement(),
+      this.pressNewsController.getElement()
+    );
+  }
 
-    changeToPrevPress() {
-        this.model.movePrevPress();
-    }
-
-    handleArrowButtonClick(direction) {
-        if (direction === 'prev') {
-            this.changeToPrevPress();
-        } else if (direction === 'next') {
-            this.changeToNextPress();
-        }
-    }
-
-    updateModel() {
-        this.model.updateModel();
-    }
-    
-      render() {
-        this.view.render(
-            this.pressCategoryController.getElement(),
-            this.pressInfoController.getElement(),
-            this.pressNewsController.getElement()
-        );
-      }
-
-    getElement() {
-        return this.view.getElement();
-    }
+  getElement() {
+    return this.view.getElement();
+  }
 }
 
 export default NewsListController;

--- a/newsstand/src/views/newsList/newsListController.js
+++ b/newsstand/src/views/newsList/newsListController.js
@@ -1,0 +1,75 @@
+import NewsListModel from './newsListModel.js';
+import NewsListView from './newsListView.js';
+
+import PressCategoryController from './pressCategory/pressCategoryController.js';
+import PressInfoController from './pressInfo/pressInfoController.js';
+import PressNewsController from './pressNews/pressNewsController.js';
+
+import intervalManager from '../../manager/intervalManager.js';
+import { IntervalKey, IntervalConst } from '../../namespace/intervalKey.js';
+import globalState from '../../app/GlobalState.js';
+import { StateKey } from '../../namespace/StateKey.js';
+import DataManager from '../../manager/dataManager.js';
+
+class NewsListController {
+    constructor() {
+        this.model = new NewsListModel();
+        this.view = new NewsListView();
+
+        this.pressCategoryController = new PressCategoryController();
+        this.pressInfoController = new PressInfoController();
+        this.pressNewsController = new PressNewsController();
+
+        this.view.render(
+            this.pressCategoryController.getElement(),
+            this.pressInfoController.getElement(),
+            this.pressNewsController.getElement()
+        );
+
+        globalState.subscribe(StateKey.tabFields, (value) => this.updateModel(value))
+        // globalState.subscribe(StateKey.isAllPress, this.updateModel) => 안됨
+        this.updateModel()
+
+        intervalManager.startTimer(IntervalKey.Progress, this.changeToNextPress.bind(this), IntervalConst.ProgressTime);
+
+        this.view.addEventListenerToArrowButton(this.handleArrowButtonClick.bind(this));
+    }
+
+    handleChangeCategory(index) {
+        this.model.updateSelectedCategory(index);
+    }
+
+    changeToNextPress() {
+        this.model.moveNextPress();
+    }
+
+    changeToPrevPress() {
+        this.model.movePrevPress();
+    }
+
+    handleArrowButtonClick(direction) {
+        if (direction === 'prev') {
+            this.changeToPrevPress();
+        } else if (direction === 'next') {
+            this.changeToNextPress();
+        }
+    }
+
+    updateModel() {
+        this.model.updateModel();
+    }
+    
+      render() {
+        this.view.render(
+            this.pressCategoryController.getElement(),
+            this.pressInfoController.getElement(),
+            this.pressNewsController.getElement()
+        );
+      }
+
+    getElement() {
+        return this.view.getElement();
+    }
+}
+
+export default NewsListController;

--- a/newsstand/src/views/newsList/newsListModel.js
+++ b/newsstand/src/views/newsList/newsListModel.js
@@ -3,63 +3,78 @@ import { StateKey } from "../../namespace/StateKey.js";
 
 class NewsListModel {
     constructor() {
-        this.selectedPressIndex = globalState.getState(StateKey.selectedCategoryCountIndex);
-        this.selectedCategoryIndex = globalState.getState(StateKey.selectedCategoryIndex);
+        const initialTabFields = globalState.getState(StateKey.TABFIELDS);
+        const initialSelectedCategoryCountIndex = globalState.getState(StateKey.SELECTED_CATEGORY_COUNT_INDEX);
+        const initialSelectedCategoryIndex = globalState.getState(StateKey.SELECTED_CATEGORY_INDEX);
+        this.state = {
+            tabFields: initialTabFields,
+            selectedCategoryCountIndex: initialSelectedCategoryCountIndex,
+            selectedCategoryIndex: initialSelectedCategoryIndex,
 
-
-        this.tabFieldsLength = 0;
-        this.tabDataLength = 0;
+            tabFieldsLength: initialTabFields.length,
+            tabDataLength: initialTabFields[initialSelectedCategoryIndex].tabData.length,
+        }
     }
 
-    updateModel() {
-        this.tabFieldsLength = globalState.getState(StateKey.tabFields).length;
-        this.tabDataLength = globalState.getState(StateKey.tabFields)[this.selectedCategoryIndex].tabData.length;
+    getState() {
+        return this.state;
+    }
+
+    setState(newState) {
+        this.state = { ...this.state, ...newState };
+        this.setTabFieldsLength()
+        this.setTabDataLength()
+    }
+
+    setTabFieldsLength() {
+        this.state.tabFieldsLength = this.state.tabFields.length;
+    }
+
+    setTabDataLength() {
+        this.state.tabDataLength = this.state.tabFields[this.state.selectedCategoryIndex].tabData.length;
     }
 
     moveNextPress() {
-        this.selectedPressIndex += 1;
-        if (this.selectedPressIndex >= this.tabDataLength) {
-            this.selectedPressIndex = 0;
-            this.moveNextCategory();
-        }
+        this.state.selectedCategoryCountIndex += 1;
 
-        globalState.setState(StateKey.selectedCategoryCountIndex, this.selectedPressIndex);
+        if (this.state.selectedCategoryCountIndex >= this.state.tabDataLength) {
+            this.moveNextCategory();
+        } else {
+            globalState.setState(StateKey.SELECTED_CATEGORY_COUNT_INDEX, this.state.selectedCategoryCountIndex);
+        }
     }
 
     movePrevPress() {
-        this.selectedPressIndex -= 1;
+        this.state.selectedCategoryCountIndex -= 1;
 
-        if (this.selectedPressIndex < 0) {
+        if (this.state.selectedCategoryCountIndex < 0) {
             this.movePrevCategory();
         } else {
-            globalState.setState(StateKey.selectedCategoryCountIndex, this.selectedPressIndex);
+            globalState.setState(StateKey.SELECTED_CATEGORY_COUNT_INDEX, this.state.selectedCategoryCountIndex);
         }
     }
 
     moveNextCategory() {
-        this.selectedCategoryIndex += 1;
-        if (this.selectedCategoryIndex >= this.tabFieldsLength) {
-            this.selectedCategoryIndex = 0;
+        this.state.selectedCategoryIndex += 1;
+        if (this.state.selectedCategoryIndex >= this.state.tabFieldsLength) {
+            this.state.selectedCategoryIndex = 0;
         }
-        this.selectedPressIndex = 0;
+        this.state.selectedCategoryCountIndex = 0;
 
-        globalState.setState(StateKey.selectedCategoryIndex, this.selectedCategoryIndex);
-        globalState.setState(StateKey.selectedCategoryCountIndex, this.selectedPressIndex);
+        globalState.setState(StateKey.SELECTED_CATEGORY_COUNT_INDEX, this.state.selectedCategoryCountIndex);
+        globalState.setState(StateKey.SELECTED_CATEGORY_INDEX, this.state.selectedCategoryIndex);
     }
 
     movePrevCategory() {
-        this.selectedCategoryIndex -= 1;
-        if (this.selectedCategoryIndex < 0) {
-            this.selectedCategoryIndex = this.tabFieldsLength - 1;
+        this.state.selectedCategoryIndex -= 1;
+        if (this.state.selectedCategoryIndex < 0) {
+            this.state.selectedCategoryIndex = this.state.tabFieldsLength - 1;
         }
-        this.selectedPressIndex = 0;
+        this.state.selectedCategoryCountIndex = 0;
 
-        globalState.setState(StateKey.selectedCategoryIndex, this.selectedCategoryIndex);
-        globalState.setState(StateKey.selectedCategoryCountIndex, this.selectedPressIndex);
-    }
-
-    getCountInfo() {
-        return this.isAllPress ? `${this.selectedPressIndex + 1}/${this.getSelectedCategory().tabData.length}` : null;
+        globalState.setState(StateKey.SELECTED_CATEGORY_COUNT_INDEX, this.state.selectedCategoryCountIndex);
+        globalState.setState(StateKey.SELECTED_CATEGORY_INDEX, this.state.selectedCategoryIndex);
+       
     }
 }
 

--- a/newsstand/src/views/newsList/newsListModel.js
+++ b/newsstand/src/views/newsList/newsListModel.js
@@ -1,0 +1,66 @@
+import globalState from "../../app/GlobalState.js";
+import { StateKey } from "../../namespace/StateKey.js";
+
+class NewsListModel {
+    constructor() {
+        this.selectedPressIndex = globalState.getState(StateKey.selectedCategoryCountIndex);
+        this.selectedCategoryIndex = globalState.getState(StateKey.selectedCategoryIndex);
+
+
+        this.tabFieldsLength = 0;
+        this.tabDataLength = 0;
+    }
+
+    updateModel() {
+        this.tabFieldsLength = globalState.getState(StateKey.tabFields).length;
+        this.tabDataLength = globalState.getState(StateKey.tabFields)[this.selectedCategoryIndex].tabData.length;
+    }
+
+    moveNextPress() {
+        this.selectedPressIndex += 1;
+        if (this.selectedPressIndex >= this.tabDataLength) {
+            this.selectedPressIndex = 0;
+            this.moveNextCategory();
+        }
+
+        globalState.setState(StateKey.selectedCategoryCountIndex, this.selectedPressIndex);
+    }
+
+    movePrevPress() {
+        this.selectedPressIndex -= 1;
+
+        if (this.selectedPressIndex < 0) {
+            this.movePrevCategory();
+        } else {
+            globalState.setState(StateKey.selectedCategoryCountIndex, this.selectedPressIndex);
+        }
+    }
+
+    moveNextCategory() {
+        this.selectedCategoryIndex += 1;
+        if (this.selectedCategoryIndex >= this.tabFieldsLength) {
+            this.selectedCategoryIndex = 0;
+        }
+        this.selectedPressIndex = 0;
+
+        globalState.setState(StateKey.selectedCategoryIndex, this.selectedCategoryIndex);
+        globalState.setState(StateKey.selectedCategoryCountIndex, this.selectedPressIndex);
+    }
+
+    movePrevCategory() {
+        this.selectedCategoryIndex -= 1;
+        if (this.selectedCategoryIndex < 0) {
+            this.selectedCategoryIndex = this.tabFieldsLength - 1;
+        }
+        this.selectedPressIndex = 0;
+
+        globalState.setState(StateKey.selectedCategoryIndex, this.selectedCategoryIndex);
+        globalState.setState(StateKey.selectedCategoryCountIndex, this.selectedPressIndex);
+    }
+
+    getCountInfo() {
+        return this.isAllPress ? `${this.selectedPressIndex + 1}/${this.getSelectedCategory().tabData.length}` : null;
+    }
+}
+
+export default NewsListModel;

--- a/newsstand/src/views/newsList/newsListView.js
+++ b/newsstand/src/views/newsList/newsListView.js
@@ -1,0 +1,39 @@
+class NewsListView {
+    constructor() {
+        this.element = document.createElement('div');
+        this.element.className = 'news-container';
+    }
+
+    render(pressCategoryViewElement, pressInfoViewElement, pressNewsViewElement) {
+        this.element.innerHTML = `
+            <img id="left-arrow" class="arrow-button" src="../../assets/icons/left-arrow-button.svg" alt="left arrow icon">
+            <div class="news-content-container"></div>
+            <img id="right-arrow" class="arrow-button" src="../../assets/icons/right-arrow-button.svg" alt="right arrow icon">
+        `;
+
+        const newsContentContainer = this.element.querySelector('.news-content-container');
+        newsContentContainer.innerHTML = '';
+        newsContentContainer.appendChild(pressCategoryViewElement);
+        newsContentContainer.appendChild(pressInfoViewElement);
+        newsContentContainer.appendChild(pressNewsViewElement);
+    }
+
+    getElement() {
+        return this.element;
+    }
+
+    addEventListenerToArrowButton(callback) {
+        const buttons = this.element.querySelectorAll('.arrow-button');
+        buttons.forEach(button => {
+            button.addEventListener('click', (event) => {
+                if (button.id === "left-arrow") {
+                    callback('prev');
+                } else if (event.target.id === "right-arrow") {
+                    callback('next');
+                }
+            });
+        });
+    }
+}
+
+export default NewsListView;

--- a/newsstand/src/views/newsList/newsListView.js
+++ b/newsstand/src/views/newsList/newsListView.js
@@ -1,7 +1,8 @@
 class NewsListView {
-    constructor() {
+    constructor({onClickArrowButton}) {
         this.element = document.createElement('div');
         this.element.className = 'news-container';
+        this.onClickArrowButton = onClickArrowButton;
     }
 
     render(pressCategoryViewElement, pressInfoViewElement, pressNewsViewElement) {
@@ -16,23 +17,29 @@ class NewsListView {
         newsContentContainer.appendChild(pressCategoryViewElement);
         newsContentContainer.appendChild(pressInfoViewElement);
         newsContentContainer.appendChild(pressNewsViewElement);
+
+        this.addEventListenerToArrowButton();
     }
 
-    getElement() {
-        return this.element;
-    }
-
-    addEventListenerToArrowButton(callback) {
+    addEventListenerToArrowButton() {
         const buttons = this.element.querySelectorAll('.arrow-button');
         buttons.forEach(button => {
             button.addEventListener('click', (event) => {
                 if (button.id === "left-arrow") {
-                    callback('prev');
+                    this.onClickArrowButton('prev');
                 } else if (event.target.id === "right-arrow") {
-                    callback('next');
+                    this.onClickArrowButton('next');
                 }
             });
         });
+    }
+
+    update() {
+
+    }
+
+    getElement() {
+        return this.element;
     }
 }
 

--- a/newsstand/src/views/newsList/newsListView.js
+++ b/newsstand/src/views/newsList/newsListView.js
@@ -1,18 +1,29 @@
+const CLASS = Object.freeze({
+    NEWS_CONTAINER: 'news-container',
+    NEWS_CONTENT_CONTAINER: 'news-content-container',
+    ARROW_BUTTON: 'arrow-button'
+});
+
+const ID = Object.freeze({
+    LEFT_ARROW: 'left-arrow',
+    RIGHT_ARROW: 'right-arrow'
+});
+
 class NewsListView {
-    constructor({onClickArrowButton}) {
+    constructor({ onClickArrowButton }) {
         this.element = document.createElement('div');
-        this.element.className = 'news-container';
+        this.element.className = CLASS.NEWS_CONTAINER;
         this.onClickArrowButton = onClickArrowButton;
     }
 
     render(pressCategoryViewElement, pressInfoViewElement, pressNewsViewElement) {
         this.element.innerHTML = `
-            <img id="left-arrow" class="arrow-button" src="../../assets/icons/left-arrow-button.svg" alt="left arrow icon">
-            <div class="news-content-container"></div>
-            <img id="right-arrow" class="arrow-button" src="../../assets/icons/right-arrow-button.svg" alt="right arrow icon">
+            <img id="${ID.LEFT_ARROW}" class="${CLASS.ARROW_BUTTON}" src="../../assets/icons/left-arrow-button.svg" alt="left arrow icon">
+            <div class="${CLASS.NEWS_CONTENT_CONTAINER}"></div>
+            <img id="${ID.RIGHT_ARROW}" class="${CLASS.ARROW_BUTTON}" src="../../assets/icons/right-arrow-button.svg" alt="right arrow icon">
         `;
 
-        const newsContentContainer = this.element.querySelector('.news-content-container');
+        const newsContentContainer = this.element.querySelector(`.${CLASS.NEWS_CONTENT_CONTAINER}`);
         newsContentContainer.innerHTML = '';
         newsContentContainer.appendChild(pressCategoryViewElement);
         newsContentContainer.appendChild(pressInfoViewElement);
@@ -22,12 +33,12 @@ class NewsListView {
     }
 
     addEventListenerToArrowButton() {
-        const buttons = this.element.querySelectorAll('.arrow-button');
+        const buttons = this.element.querySelectorAll(`.${CLASS.ARROW_BUTTON}`);
         buttons.forEach(button => {
             button.addEventListener('click', (event) => {
-                if (button.id === "left-arrow") {
+                if (button.id === ID.LEFT_ARROW) {
                     this.onClickArrowButton('prev');
-                } else if (event.target.id === "right-arrow") {
+                } else if (event.target.id === ID.RIGHT_ARROW) {
                     this.onClickArrowButton('next');
                 }
             });

--- a/newsstand/src/views/newsList/pressCategory/pressCategory.js
+++ b/newsstand/src/views/newsList/pressCategory/pressCategory.js
@@ -49,47 +49,30 @@ const PressCategoryContainer = ({
         }
     }
 
-    function createButton(category, index) {
-        const button = document.createElement('button');
-        button.className = 'press-category-button';
-        button.id = `press-category-${index}`;
-
-        const progressBar = document.createElement('div');
-        progressBar.className = 'press-category-button-progress';   
-        progressBar.id = `press-category-${index}`;
-
-        const container = document.createElement('div');
-        container.className = 'press-category-span-container';
-        container.id = `press-category-${index}`;
-
-        const tabNameSpan = document.createElement('span');
-        tabNameSpan.id = `press-category-${index}`;
-        tabNameSpan.textContent = category.tabName;
-
-        const countSpan = document.createElement('span');
-        countSpan.id = `press-category-${index}`;
-        countSpan.className = `press-count-span`;
-        countSpan.textContent = '';
-
-        container.appendChild(tabNameSpan);
-        container.appendChild(countSpan);
-
-        button.appendChild(progressBar);
-        button.appendChild(container);
-        return button;
+    function createButtonHTML(category, index) {
+        return `
+            <button class="press-category-button" id="press-category-${index}">
+                <div class="press-category-button-progress" id="press-category-${index}"></div>
+                <div class="press-category-span-container" id="press-category-${index}">
+                    <span id="press-category-${index}">${category.tabName}</span>
+                    <span id="press-category-${index}" class="press-count-span"></span>
+                </div>
+            </button>
+        `;
     }
-
+    
     function renderButtons() {
-        element.innerHTML = '';
-        buttons = [];
-        progressBars = [];
+        let buttonsHTML = '';
         tabFields.forEach((category, index) => {
-            const button = createButton(category, index);
-            element.appendChild(button);
-            buttons.push(button);
-            progressBars.push(button.querySelector('.press-category-button-progress'));
+            buttonsHTML += createButtonHTML(category, index);
         });
+    
+        element.innerHTML = buttonsHTML;
+    
+        buttons = Array.from(element.querySelectorAll('.press-category-button'));
+        progressBars = Array.from(element.querySelectorAll('.press-category-button-progress'));
     }
+    
 
     function addEventListeners() {
         buttons.forEach(button => {

--- a/newsstand/src/views/newsList/pressCategory/pressCategoryController.js
+++ b/newsstand/src/views/newsList/pressCategory/pressCategoryController.js
@@ -1,22 +1,56 @@
-// import { createModel } from "./pressCategoryModel.js";
-// import { createView } from "./pressCategoryView.js";
+import { StateKey } from '../../../namespace/StateKey.js';
+import globalState from '../../../app/GlobalState.js';
+import PressCategoryModel from "./pressCategoryModel.js";
+import PressCategoryView from './PressCategoryView.js';
 
-// export function createController({ tabs, onChangeCategory }) {
-//   const model = createModel(tabs);
-//   const view = createView({ model, onChangeCategory });
+class PressCategoryController {
+    constructor() {
+        this.model = new PressCategoryModel();
+        this.view = new PressCategoryView({
+            onClickCategory: () => { this.onChangeCategory(); }
+        });
 
-//   function init() {
-//     view.render();
-//   }
+        this.render();
 
-//   function updateTabs(newTabs) {
-//     model.setTabs(newTabs);
-//     view.render();
-//   }
+        globalState.subscribe(StateKey.isAllPress, (value) => {
+            this.updateModel(StateKey.isAllPress, value);
+        });
 
-//   return {
-//     getElement: () => view.element,
-//     updateTabs,
-//     init,
-//   };
-// }
+        globalState.subscribe(StateKey.tabFields, (value) => {
+            this.updateModel(StateKey.tabFields, value);
+        });
+
+        globalState.subscribe(StateKey.selectedCategoryIndex, (value) => {
+            this.updateModel(StateKey.selectedCategoryIndex, value);
+        });
+
+        globalState.subscribe(StateKey.selectedCategoryCountIndex, (value) => {
+            this.updateModel(StateKey.selectedCategoryCountIndex, value);
+        });
+
+        this.updateModel();
+    }
+
+    updateModel(key, value) {
+        if (key && value) {
+            this.model.setState({ [key]: value });
+        } 
+
+        const newState = this.model.getState();
+        this.view.update(newState);
+    }
+
+    render() {
+        this.view.render();
+    }
+
+    onChangeCategory(intId) {
+        this.model.setSelectedIndex(intId);
+    }
+
+    getElement() {
+        return this.view.getElement();
+    }
+}
+
+export default PressCategoryController;

--- a/newsstand/src/views/newsList/pressCategory/pressCategoryController.js
+++ b/newsstand/src/views/newsList/pressCategory/pressCategoryController.js
@@ -7,34 +7,34 @@ class PressCategoryController {
     constructor() {
         this.model = new PressCategoryModel();
         this.view = new PressCategoryView({
-            onClickCategory: () => { this.onChangeCategory(); }
+            onClickCategory: (id) => { this.onChangeCategory(id); }
         });
 
         this.render();
 
-        globalState.subscribe(StateKey.isAllPress, (value) => {
-            this.updateModel(StateKey.isAllPress, value);
+        globalState.subscribe(StateKey.IS_ALLPRESS, (value) => {
+            this.updateModel(StateKey.IS_ALLPRESS, value);
         });
 
-        globalState.subscribe(StateKey.tabFields, (value) => {
-            this.updateModel(StateKey.tabFields, value);
+        globalState.subscribe(StateKey.TABFIELDS, (value) => {
+            this.updateModel(StateKey.TABFIELDS, value);
         });
 
-        globalState.subscribe(StateKey.selectedCategoryIndex, (value) => {
-            this.updateModel(StateKey.selectedCategoryIndex, value);
+        globalState.subscribe(StateKey.SELECTED_CATEGORY_INDEX, (value) => {
+            this.updateModel(StateKey.SELECTED_CATEGORY_INDEX, value);
         });
 
-        globalState.subscribe(StateKey.selectedCategoryCountIndex, (value) => {
-            this.updateModel(StateKey.selectedCategoryCountIndex, value);
+        globalState.subscribe(StateKey.SELECTED_CATEGORY_COUNT_INDEX, (value) => {
+            this.updateModel(StateKey.SELECTED_CATEGORY_COUNT_INDEX, value);
         });
 
-        this.updateModel();
+        this.updateModel(); 
     }
 
     updateModel(key, value) {
-        if (key && value) {
+        if (key) {
             this.model.setState({ [key]: value });
-        } 
+        }
 
         const newState = this.model.getState();
         this.view.update(newState);

--- a/newsstand/src/views/newsList/pressCategory/pressCategoryModel.js
+++ b/newsstand/src/views/newsList/pressCategory/pressCategoryModel.js
@@ -1,10 +1,37 @@
-// // pressCategoryModel.js
-// export function createModel(tabs) {
-//     return {
-//       tabs: tabs,
-//       setTabs: (newTabs) => {
-//         tabs = newTabs;
-//       },
-//     };
-//   }
-  
+import globalState from '../../../app/GlobalState.js';
+import { StateKey } from '../../../namespace/StateKey.js';
+
+class PressCategoryModel {
+    constructor() {
+        this.state = {
+            isAllPress: globalState.getState(StateKey.isAllPress),
+            tabFields: globalState.getState(StateKey.tabFields),
+            selectedCategoryIndex: globalState.getState(StateKey.selectedCategoryIndex),
+            selectedCategoryCountIndex: globalState.getState(StateKey.selectedCategoryCountIndex),
+            countInfo: ''
+        };
+
+        this.setCountInfo()
+    }
+
+    setCountInfo() {
+        this.state.countInfo = `${this.state.selectedCategoryCountIndex + 1}/${this.state.tabFields[this.state.selectedCategoryIndex].tabData.length}`;
+    }
+
+    getState() {
+        return this.state;
+    }
+
+    setState(newState) {
+        this.state = { ...this.state, ...newState };
+        this.setCountInfo();
+        console.log(this.state.countInfo);
+    }
+
+    setSelectedIndex(index) {
+        this.setState({ selectedCategoryIndex: index });
+        globalState.setState(StateKey.selectedCategoryIndex, index);
+    }
+}
+
+export default PressCategoryModel;

--- a/newsstand/src/views/newsList/pressCategory/pressCategoryModel.js
+++ b/newsstand/src/views/newsList/pressCategory/pressCategoryModel.js
@@ -4,10 +4,10 @@ import { StateKey } from '../../../namespace/StateKey.js';
 class PressCategoryModel {
     constructor() {
         this.state = {
-            isAllPress: globalState.getState(StateKey.isAllPress),
-            tabFields: globalState.getState(StateKey.tabFields),
-            selectedCategoryIndex: globalState.getState(StateKey.selectedCategoryIndex),
-            selectedCategoryCountIndex: globalState.getState(StateKey.selectedCategoryCountIndex),
+            isAllPress: globalState.getState(StateKey.IS_ALLPRESS),
+            tabFields: globalState.getState(StateKey.TABFIELDS),
+            selectedCategoryIndex: globalState.getState(StateKey.SELECTED_CATEGORY_INDEX),
+            selectedCategoryCountIndex: globalState.getState(StateKey.SELECTED_CATEGORY_COUNT_INDEX),
             countInfo: ''
         };
 
@@ -25,12 +25,14 @@ class PressCategoryModel {
     setState(newState) {
         this.state = { ...this.state, ...newState };
         this.setCountInfo();
-        console.log(this.state.countInfo);
     }
 
     setSelectedIndex(index) {
         this.setState({ selectedCategoryIndex: index });
-        globalState.setState(StateKey.selectedCategoryIndex, index);
+        this.setState({ selectedCategoryCountIndex: 0 });
+
+        globalState.setState(StateKey.SELECTED_CATEGORY_INDEX, index);
+        globalState.setState(StateKey.SELECTED_CATEGORY_COUNT_INDEX, 0);
     }
 }
 

--- a/newsstand/src/views/newsList/pressCategory/pressCategoryView.js
+++ b/newsstand/src/views/newsList/pressCategory/pressCategoryView.js
@@ -1,9 +1,19 @@
 import { separateId } from "../../../utils/utils.js";
 
+const CLASS = Object.freeze({
+    PRESS_CATEGORY_CONTAINER: 'press-category-container',
+    PRESS_CATEGORY_BUTTON: 'press-category-button',
+    PRESS_CATEGORY_BUTTON_SELECTED: 'press-category-button-selected',
+    PRESS_CATEGORY_BUTTON_PROGRESS: 'press-category-button-progress',
+    PRESS_CATEGORY_SPAN_CONTAINER: 'press-category-span-container',
+    PRESS_COUNT_SPAN: 'press-count-span',
+    SELECTED: 'selected'
+});
+
 class PressCategoryView {
-    constructor({onClickCategory}) {
+    constructor({ onClickCategory }) {
         this.element = document.createElement('div');
-        this.element.className = 'press-category-container';
+        this.element.className = CLASS.PRESS_CATEGORY_CONTAINER;
         this.categoryClickCallback = onClickCategory;
     }
 
@@ -11,14 +21,14 @@ class PressCategoryView {
         this.element.innerHTML = '';
     }
 
-    update( {tabFields, selectedCategoryIndex, isAllPress, countInfo}) {
+    update({ tabFields, selectedCategoryIndex, isAllPress, countInfo }) {
         this.element.innerHTML = this.createButtonHTML(tabFields);
         this.attachButtonListeners();
         this.updateSelectedButtonStyle(selectedCategoryIndex, countInfo, isAllPress);
     }
 
     attachButtonListeners() {
-        const buttons = this.element.querySelectorAll('.press-category-button');
+        const buttons = this.element.querySelectorAll(`.${CLASS.PRESS_CATEGORY_BUTTON}`);
 
         buttons.forEach(button => {
             button.addEventListener('click', () => {
@@ -32,11 +42,11 @@ class PressCategoryView {
         let buttonsHTML = '';
         tabFields.forEach((category, index) => {
             buttonsHTML += `
-                <button class="press-category-button" id=press-category-${index}>
-                    <div class="press-category-button-progress"></div>
-                    <div class="press-category-span-container">
+                <button class="${CLASS.PRESS_CATEGORY_BUTTON}" id="press-category-${index}">
+                    <div class="${CLASS.PRESS_CATEGORY_BUTTON_PROGRESS}"></div>
+                    <div class="${CLASS.PRESS_CATEGORY_SPAN_CONTAINER}">
                         <span>${category.tabName}</span>
-                        <span class="press-count-span"></span>
+                        <span class="${CLASS.PRESS_COUNT_SPAN}"></span>
                     </div>
                 </button>
             `;
@@ -45,27 +55,27 @@ class PressCategoryView {
     }
 
     updateSelectedButtonStyle(selectedIndex, countInfo, isAllPress) {
-        const buttons = this.element.querySelectorAll('.press-category-button');
+        const buttons = this.element.querySelectorAll(`.${CLASS.PRESS_CATEGORY_BUTTON}`);
 
         buttons.forEach((button, index) => {
             const isSelected = index === selectedIndex;
-            button.className = isSelected ? 'press-category-button-selected' : 'press-category-button';
+            button.className = isSelected ? CLASS.PRESS_CATEGORY_BUTTON_SELECTED : CLASS.PRESS_CATEGORY_BUTTON;
             this.updateInfoSpanStyle(button, isSelected, countInfo, isAllPress);
             this.updateProgressBarStyle(button, isSelected);
         });
     }
 
     updateProgressBarStyle(button, isSelected) {
-        const progressBar = button.querySelector('.press-category-button-progress');
+        const progressBar = button.querySelector(`.${CLASS.PRESS_CATEGORY_BUTTON_PROGRESS}`);
         if (isSelected) {
-            progressBar.classList.add('selected');
+            progressBar.classList.add(CLASS.SELECTED);
         } else {
-            progressBar.classList.remove('selected');
+            progressBar.classList.remove(CLASS.SELECTED);
         }
     }
 
     updateInfoSpanStyle(button, isSelected, countInfo, isAllPress) {
-        const infoSpan = button.querySelector('.press-count-span');
+        const infoSpan = button.querySelector(`.${CLASS.PRESS_COUNT_SPAN}`);
         if (infoSpan) {
             if (isAllPress) {
                 infoSpan.textContent = isSelected ? `${countInfo}` : "";

--- a/newsstand/src/views/newsList/pressCategory/pressCategoryView.js
+++ b/newsstand/src/views/newsList/pressCategory/pressCategoryView.js
@@ -1,92 +1,68 @@
-// // pressCategoryView.js
-// import { separateId } from "../../../utils/utils.js";
+import { separateId } from "../../../utils/utils.js";
 
-// export function createView({ model, onChangeCategory }) {
-//   const element = document.createElement("div");
-//   element.className = "press-category-container";
+class PressCategoryView {
+    constructor({onClickCategory}) {
+        this.element = document.createElement('div');
+        this.element.className = 'press-category-container';
+        this.categoryClickCallback = onClickCategory;
+    }
 
-//   let buttons = [];
-//   let progressBars = [];
+    render() {
+        this.element.innerHTML = '';
+    }
 
-//   function onClickEvent(event) {
-//     const intId = separateId(event.target.id);
-//     onChangeCategory(intId);
-//   }
+    update( {tabFields, selectedCategoryIndex, isAllPress, countInfo}) {
+        this.element.innerHTML = this.createButtonHTML(isAllPress, tabFields, countInfo);
+        this.updateSelectedButtonStyle(selectedCategoryIndex);
+    }
 
-//   function updateSelectedButtonStyle() {
-//     const rootStyles = getComputedStyle(document.documentElement);
+    attachButtonListeners() {
+        const buttons = this.element.querySelectorAll('.press-category-button');
+        buttons.forEach(button => {
+            button.addEventListener('click', () => {
+                const intId = separateId(button.id);
+                this.categoryClickCallback(intId);
+            });
+        });
+    }
 
-//     buttons.forEach((button, index) => {
-//       const tabModel = model.tabs[index];
-//       const isSelected = tabModel.selectedIndex !== undefined;
+    createButtonHTML(isAllPress, tabFields, countInfo) {
+        let buttonsHTML = '';
+        tabFields.forEach((category, index) => {
+            buttonsHTML += `
+                <button class="press-category-button" id=press-category-${index}>
+                    <div class="press-category-button-progress"></div>
+                    <div class="press-category-span-container">
+                        <span>${category.tabName}</span>
+                        <span class="press-count-span">${isAllPress ? countInfo : '>'}</span>
+                    </div>
+                </button>
+            `;
+        });
+        return buttonsHTML;
+    }
 
-//       button.style.backgroundColor = isSelected
-//         ? rootStyles.getPropertyValue("--color-surface-brand-alt")
-//         : "transparent";
-//       button.style.color = isSelected
-//         ? rootStyles.getPropertyValue("--color-text-white-default")
-//         : rootStyles.getPropertyValue("--color-text-weak");
+    updateSelectedButtonStyle(selectedIndex) {
+        const buttons = this.element.querySelectorAll('.press-category-button');
 
-//       const categoryCountSpan = button.querySelector(".press-count-span");
-//       if (categoryCountSpan) {
-//         button.style.width = isSelected ? "166px" : "max-content";
-//         categoryCountSpan.textContent = isSelected
-//           ? `${tabModel.selectedIndex + 1}/${tabModel.tabDataCount}`
-//           : "";
-//       }
+        buttons.forEach((button, index) => {
+            const isSelected = index === selectedIndex;
+            button.className = isSelected ? 'press-category-button-selected' : 'press-category-button';
+            this.updateProgressBarStyle(button.querySelector('.press-category-button-progress'), isSelected);
+        });
+    }
 
-//       if (isSelected) {
-//         progressBars[index].classList.add("selected");
-//       } else {
-//         progressBars[index].classList.remove("selected");
-//       }
-//     });
-//   }
+    updateProgressBarStyle(progressBar, isSelected) {
+        if (isSelected) {
+            progressBar.classList.add('selected');
+        } else {
+            progressBar.classList.remove('selected');
+        }
+    }
 
-//   function createButtonHTML(category, index) {
-//     const isSelected = category.selectedIndex !== undefined;
-//     const countSpanText = isSelected
-//       ? `${category.selectedIndex + 1}/${category.tabDataCount}`
-//       : "";
+    getElement() {
+        return this.element;
+    }
+}
 
-//     return `
-//       <button class="press-category-button" id="press-category-${index}">
-//         <div class="press-category-button-progress"></div>
-//         <div class="press-category-span-container">
-//           <span>${category.tabName}</span>
-//           <span class="press-count-span">${countSpanText}</span>
-//         </div>
-//       </button>
-//     `;
-//   }
-
-//   function renderButtons() {
-//     element.innerHTML = "";
-//     buttons = [];
-//     progressBars = [];
-
-//     model.tabs.forEach((category, index) => {
-//       const buttonHTML = createButtonHTML(category, index);
-//       element.innerHTML += buttonHTML;
-//     });
-
-//     buttons = Array.from(element.querySelectorAll(".press-category-button"));
-//     progressBars = Array.from(
-//       element.querySelectorAll(".press-category-button-progress")
-//     );
-
-//     buttons.forEach((button) => {
-//       button.addEventListener("click", onClickEvent);
-//     });
-//   }
-
-//   function render() {
-//     renderButtons();
-//     updateSelectedButtonStyle();
-//   }
-
-//   return {
-//     element,
-//     render,
-//   };
-// }
+export default PressCategoryView;

--- a/newsstand/src/views/newsList/pressCategory/pressCategoryView.js
+++ b/newsstand/src/views/newsList/pressCategory/pressCategoryView.js
@@ -12,12 +12,14 @@ class PressCategoryView {
     }
 
     update( {tabFields, selectedCategoryIndex, isAllPress, countInfo}) {
-        this.element.innerHTML = this.createButtonHTML(isAllPress, tabFields, countInfo);
-        this.updateSelectedButtonStyle(selectedCategoryIndex);
+        this.element.innerHTML = this.createButtonHTML(tabFields);
+        this.attachButtonListeners();
+        this.updateSelectedButtonStyle(selectedCategoryIndex, countInfo, isAllPress);
     }
 
     attachButtonListeners() {
         const buttons = this.element.querySelectorAll('.press-category-button');
+
         buttons.forEach(button => {
             button.addEventListener('click', () => {
                 const intId = separateId(button.id);
@@ -26,7 +28,7 @@ class PressCategoryView {
         });
     }
 
-    createButtonHTML(isAllPress, tabFields, countInfo) {
+    createButtonHTML(tabFields) {
         let buttonsHTML = '';
         tabFields.forEach((category, index) => {
             buttonsHTML += `
@@ -34,7 +36,7 @@ class PressCategoryView {
                     <div class="press-category-button-progress"></div>
                     <div class="press-category-span-container">
                         <span>${category.tabName}</span>
-                        <span class="press-count-span">${isAllPress ? countInfo : '>'}</span>
+                        <span class="press-count-span"></span>
                     </div>
                 </button>
             `;
@@ -42,21 +44,34 @@ class PressCategoryView {
         return buttonsHTML;
     }
 
-    updateSelectedButtonStyle(selectedIndex) {
+    updateSelectedButtonStyle(selectedIndex, countInfo, isAllPress) {
         const buttons = this.element.querySelectorAll('.press-category-button');
 
         buttons.forEach((button, index) => {
             const isSelected = index === selectedIndex;
             button.className = isSelected ? 'press-category-button-selected' : 'press-category-button';
-            this.updateProgressBarStyle(button.querySelector('.press-category-button-progress'), isSelected);
+            this.updateInfoSpanStyle(button, isSelected, countInfo, isAllPress);
+            this.updateProgressBarStyle(button, isSelected);
         });
     }
 
-    updateProgressBarStyle(progressBar, isSelected) {
+    updateProgressBarStyle(button, isSelected) {
+        const progressBar = button.querySelector('.press-category-button-progress');
         if (isSelected) {
             progressBar.classList.add('selected');
         } else {
             progressBar.classList.remove('selected');
+        }
+    }
+
+    updateInfoSpanStyle(button, isSelected, countInfo, isAllPress) {
+        const infoSpan = button.querySelector('.press-count-span');
+        if (infoSpan) {
+            if (isAllPress) {
+                infoSpan.textContent = isSelected ? `${countInfo}` : "";
+            } else {
+                infoSpan.textContent = isSelected ? ">" : "";
+            }
         }
     }
 

--- a/newsstand/src/views/newsList/pressInfo/pressInfoController.js
+++ b/newsstand/src/views/newsList/pressInfo/pressInfoController.js
@@ -15,9 +15,10 @@ class PressInfoController {
             callbackSubscribed: () => this.moveToSubscribePress()
         });
 
-        globalState.subscribe(StateKey.SELECTED_CATEGORY_COUNT_INDEX, this.updateModel.bind(this));
-
         this.render();
+
+        globalState.subscribe(StateKey.SELECTED_CATEGORY_COUNT_INDEX, () => this.updateModel());
+
         this.updateModel();
     }
 

--- a/newsstand/src/views/newsList/pressInfo/pressInfoController.js
+++ b/newsstand/src/views/newsList/pressInfo/pressInfoController.js
@@ -1,0 +1,50 @@
+import { StateKey } from "../../../namespace/StateKey.js";
+import globalState from "../../../app/GlobalState.js";
+
+import PressInfoModel from "./pressInfoModel.js";
+import PressInfoView from "./pressInfoView.js";
+
+class PressInfoController {
+    constructor() {
+        this.model = new PressInfoModel();
+        this.view = new PressInfoView({onClickChipButton: () => this.onChipButtonClick()});
+
+        globalState.subscribe(StateKey.selectedCategoryCountIndex, this.updateModel.bind(this));
+
+        this.render();
+        this.updateModel();
+    }
+
+    updateModel() {
+        const tabFields = globalState.getState(StateKey.tabFields);
+        const selectedCategoryIndex = globalState.getState(StateKey.selectedCategoryIndex);
+        const selectedCategoryCountIndex = globalState.getState(StateKey.selectedCategoryCountIndex);
+
+        const pressData = tabFields[selectedCategoryIndex].tabData[selectedCategoryCountIndex];
+
+        this.model.setPress(pressData);
+        this.view.update(pressData);
+    }
+
+    render() {
+        this.view.render();
+    }
+
+    onChipButtonClick() {
+        this.model.toggleSubscription();
+        const pressData = this.model.getPress();
+        if (pressData.subscribe === 'Y') {
+            // LOCALSTORAGE MANAGER 추가해서 구독 정보 저장하기
+            this.view.showSnackBar();
+        } else {
+            this.view.showAlert(pressData);
+        }
+        this.view.update(pressData);
+    }
+
+    getElement() {
+        return this.view.getElement();
+    }
+}
+
+export default PressInfoController;

--- a/newsstand/src/views/newsList/pressInfo/pressInfoController.js
+++ b/newsstand/src/views/newsList/pressInfo/pressInfoController.js
@@ -3,22 +3,28 @@ import globalState from "../../../app/GlobalState.js";
 
 import PressInfoModel from "./pressInfoModel.js";
 import PressInfoView from "./pressInfoView.js";
+import DataManager from "../../../manager/dataManager.js";
+import storageManager from "../../../manager/localStorageManager.js";
+import { StorageKey } from "../../../namespace/StorageKey.js";
 
 class PressInfoController {
     constructor() {
         this.model = new PressInfoModel();
-        this.view = new PressInfoView({onClickChipButton: () => this.onChipButtonClick()});
+        this.view = new PressInfoView({
+            onClickChipButton: () => this.onChipButtonClick(),
+            callbackSubscribed: () => this.moveToSubscribePress()
+        });
 
-        globalState.subscribe(StateKey.selectedCategoryCountIndex, this.updateModel.bind(this));
+        globalState.subscribe(StateKey.SELECTED_CATEGORY_COUNT_INDEX, this.updateModel.bind(this));
 
         this.render();
         this.updateModel();
     }
 
     updateModel() {
-        const tabFields = globalState.getState(StateKey.tabFields);
-        const selectedCategoryIndex = globalState.getState(StateKey.selectedCategoryIndex);
-        const selectedCategoryCountIndex = globalState.getState(StateKey.selectedCategoryCountIndex);
+        const tabFields = globalState.getState(StateKey.TABFIELDS);
+        const selectedCategoryIndex = globalState.getState(StateKey.SELECTED_CATEGORY_INDEX);
+        const selectedCategoryCountIndex = globalState.getState(StateKey.SELECTED_CATEGORY_COUNT_INDEX);
 
         const pressData = tabFields[selectedCategoryIndex].tabData[selectedCategoryCountIndex];
 
@@ -30,11 +36,23 @@ class PressInfoController {
         this.view.render();
     }
 
+    moveToSubscribePress() {
+        const tabs = DataManager.getSubscribedPressTabs();
+
+        const pressData = this.model.getPress();
+        const index = tabs.findIndex(tab => tab.tabName === pressData.mediaName);
+
+        globalState.setState(StateKey.IS_ALLPRESS, false);
+        globalState.setState(StateKey.TABFIELDS, tabs);
+        globalState.setState(StateKey.SELECTED_CATEGORY_INDEX, index);
+        globalState.setState(StateKey.SELECTED_CATEGORY_COUNT_INDEX, 0);
+    }
+
     onChipButtonClick() {
         this.model.toggleSubscription();
         const pressData = this.model.getPress();
         if (pressData.subscribe === 'Y') {
-            // LOCALSTORAGE MANAGER 추가해서 구독 정보 저장하기
+            storageManager.setStorage(StorageKey.SUBSCRIBED, pressData.mediaName);
             this.view.showSnackBar();
         } else {
             this.view.showAlert(pressData);

--- a/newsstand/src/views/newsList/pressInfo/pressInfoModel.js
+++ b/newsstand/src/views/newsList/pressInfo/pressInfoModel.js
@@ -1,0 +1,21 @@
+import globalState from '../../../app/GlobalState.js';
+
+class PressInfoModel {
+    constructor() {
+        this.press = {};
+    }
+
+    setPress(press) {
+        this.press = press;
+    }
+
+    getPress() {
+        return this.press;
+    }
+
+    toggleSubscription() {
+        this.press.subscribe = this.press.subscribe === 'Y' ? 'N' : 'Y';
+    }
+}
+
+export default PressInfoModel;

--- a/newsstand/src/views/newsList/pressInfo/pressInfoModel.js
+++ b/newsstand/src/views/newsList/pressInfo/pressInfoModel.js
@@ -2,19 +2,30 @@ import globalState from '../../../app/GlobalState.js';
 
 class PressInfoModel {
     constructor() {
-        this.press = {};
+        this.state = {
+            press: {}
+        };
     }
 
     setPress(press) {
-        this.press = press;
+        this.state.press = press;
     }
 
     getPress() {
-        return this.press;
+        return this.state.press;
     }
 
+
+    getState() {
+        return this.state;
+    }
+
+    setState(newState) {
+        this.state = { ...this.state, ...newState };
+
+    }
     toggleSubscription() {
-        this.press.subscribe = this.press.subscribe === 'Y' ? 'N' : 'Y';
+        this.state.press.subscribe = this.state.press.subscribe === 'Y' ? 'N' : 'Y';
     }
 }
 

--- a/newsstand/src/views/newsList/pressInfo/pressInfoView.js
+++ b/newsstand/src/views/newsList/pressInfo/pressInfoView.js
@@ -16,11 +16,12 @@ const ICON = Object.freeze({
 })
 
 class PressInfoView {
-    constructor({onClickChipButton}) {
+    constructor({onClickChipButton, callbackSubscribed}) {
         this.element = document.createElement('div');
         this.element.className = CLASS.PRESS_INFO_CONTAINER;
         this.chipButton = null;
         this.onClickChipButton = onClickChipButton;
+        this.callbackSubscribed = callbackSubscribed;
     }
 
     render() {
@@ -60,7 +61,7 @@ class PressInfoView {
     }
 
     showSnackBar() {
-        const snackBar = SnackBar({ title: '내가 구독한 언론사에 추가되었습니다.' });
+        const snackBar = SnackBar({ title: '내가 구독한 언론사에 추가되었습니다.' , callback: this.callbackSubscribed});
         snackBar.show();
     }
 

--- a/newsstand/src/views/newsList/pressInfo/pressInfoView.js
+++ b/newsstand/src/views/newsList/pressInfo/pressInfoView.js
@@ -1,0 +1,89 @@
+import ChipButton from "../../../components/chipButton/chipButton.js";
+import SnackBar from "../../../components/snackBar/snackBar.js";
+import Alert from "../../../components/alert/alert.js";
+import { separateId } from "../../../utils/utils.js";
+
+const CLASS = Object.freeze({
+    PRESS_INFO_CONTAINER: 'press-info-container',
+    PRESS_INFO_LOGO: 'press-info-logo',
+    PRESS_INFO_EDIT_DATE: 'press-info-edit-date',
+    CHIP_BUTTON_CONTAINER: 'chip-button-container'
+})
+
+const ICON = Object.freeze({
+    XMARK: '/newsstand/assets/icons/xmark.svg',
+    PLUS: '/newsstand/assets/icons/plus.svg'
+})
+
+class PressInfoView {
+    constructor({onClickChipButton}) {
+        this.element = document.createElement('div');
+        this.element.className = CLASS.PRESS_INFO_CONTAINER;
+        this.chipButton = null;
+        this.onClickChipButton = onClickChipButton;
+    }
+
+    render() {
+        const html = `
+            <img class="${CLASS.PRESS_INFO_LOGO}" src="" alt="press image"/>
+            <span class="${CLASS.PRESS_INFO_EDIT_DATE}"></span>
+            <div class="${CLASS.CHIP_BUTTON_CONTAINER}"></div>
+        `;
+        this.element.innerHTML = html;
+
+        const icon = ICON.PLUS;
+        const title = '구독하기';
+
+        this.renderChipButton(icon, title);
+    }
+
+    update(press) {
+        const { sourceLogo, newsDate, subscribe } = press;
+        const isSubscribed = subscribe === 'Y';
+        const icon = isSubscribed ? ICON.XMARK : ICON.PLUS;
+        const title = isSubscribed ? '' : '구독하기';
+
+        this.element.querySelector(`.${CLASS.PRESS_INFO_LOGO}`).src = sourceLogo;
+        this.element.querySelector(`.${CLASS.PRESS_INFO_EDIT_DATE}`).textContent = newsDate;
+
+        this.renderChipButton(icon, title);
+    }
+
+    renderChipButton(icon, title) {
+        if (this.chipButton) {
+            this.element.querySelector(`.${CLASS.CHIP_BUTTON_CONTAINER}`).innerHTML = '';
+        }
+
+        this.chipButton = ChipButton({ icon: icon, title: title });
+        this.chipButton.element.addEventListener('click', () => this.onClickChipButton());
+        this.element.querySelector(`.${CLASS.CHIP_BUTTON_CONTAINER}`).appendChild(this.chipButton.element);
+    }
+
+    showSnackBar() {
+        const snackBar = SnackBar({ title: '내가 구독한 언론사에 추가되었습니다.' });
+        snackBar.show();
+    }
+
+    showAlert(press) {
+        const { mediaName } = press;
+        const alert = Alert({ pressName: mediaName, handleOkButtonClick: () => this.onAlertOkButtonClick() });
+        alert.show();
+    }
+
+    onAlertOkButtonClick() {
+        this.onClickChipButton();
+    }
+
+    onClickCategory(callback) {
+        this.element.addEventListener('click', (event) => {
+            const intId = separateId(event.target.id);
+            callback(intId);
+        });
+    }
+
+    getElement() {
+        return this.element;
+    }
+}
+
+export default PressInfoView;

--- a/newsstand/src/views/newsList/pressNews/pressNewsController.js
+++ b/newsstand/src/views/newsList/pressNews/pressNewsController.js
@@ -8,10 +8,11 @@ class PressNewsController {
     this.model = new PressNewsModel();
     this.view = new PressNewsView();
 
+    this.render();
+
     globalState.subscribe(StateKey.SELECTED_CATEGORY_COUNT_INDEX, () => { this.updateModel() });
     globalState.subscribe(StateKey.SELECTED_CATEGORY_INDEX, () => { this.updateModel() });
-  
-    this.render();
+
     this.updateModel();
   }
 

--- a/newsstand/src/views/newsList/pressNews/pressNewsController.js
+++ b/newsstand/src/views/newsList/pressNews/pressNewsController.js
@@ -1,0 +1,37 @@
+import { StateKey } from "../../../namespace/StateKey.js";
+import globalState from "../../../app/GlobalState.js";
+import PressNewsModel from "./pressNewsModel.js";
+import PressNewsView from "./pressNewsView.js";
+
+class PressNewsController {
+  constructor() {
+    this.model = new PressNewsModel();
+    this.view = new PressNewsView();
+
+    globalState.subscribe(StateKey.selectedCategoryCountIndex, () => { this.updateModel() });
+  
+    this.render();
+    this.updateModel();
+  }
+
+  updateModel() {
+    const tabFields = globalState.getState(StateKey.tabFields);
+    const selectedCategoryIndex = globalState.getState(StateKey.selectedCategoryIndex);
+    const selectedCategoryCountIndex = globalState.getState(StateKey.selectedCategoryCountIndex);
+
+    const news = tabFields[selectedCategoryIndex].tabData[selectedCategoryCountIndex];
+
+    this.model.setNews(news);
+    this.view.update(news);
+  }
+
+  render() {
+    this.view.render();
+  }
+
+  getElement() {
+    return this.view.getElement();
+  }
+}
+
+export default PressNewsController;

--- a/newsstand/src/views/newsList/pressNews/pressNewsController.js
+++ b/newsstand/src/views/newsList/pressNews/pressNewsController.js
@@ -8,16 +8,18 @@ class PressNewsController {
     this.model = new PressNewsModel();
     this.view = new PressNewsView();
 
-    globalState.subscribe(StateKey.selectedCategoryCountIndex, () => { this.updateModel() });
+    globalState.subscribe(StateKey.SELECTED_CATEGORY_COUNT_INDEX, () => { this.updateModel() });
+    globalState.subscribe(StateKey.SELECTED_CATEGORY_INDEX, () => { this.updateModel() });
   
     this.render();
     this.updateModel();
   }
 
   updateModel() {
-    const tabFields = globalState.getState(StateKey.tabFields);
-    const selectedCategoryIndex = globalState.getState(StateKey.selectedCategoryIndex);
-    const selectedCategoryCountIndex = globalState.getState(StateKey.selectedCategoryCountIndex);
+
+    const tabFields = globalState.getState(StateKey.TABFIELDS);
+    const selectedCategoryIndex = globalState.getState(StateKey.SELECTED_CATEGORY_INDEX);
+    const selectedCategoryCountIndex = globalState.getState(StateKey.SELECTED_CATEGORY_COUNT_INDEX);
 
     const news = tabFields[selectedCategoryIndex].tabData[selectedCategoryCountIndex];
 

--- a/newsstand/src/views/newsList/pressNews/pressNewsModel.js
+++ b/newsstand/src/views/newsList/pressNews/pressNewsModel.js
@@ -1,0 +1,15 @@
+class PressNewsModel {
+    constructor() {
+        this.news = {};
+    }
+
+    setNews(news) {
+        this.news = news;
+    }
+
+    getNews() {
+        return this.news;
+    }
+}
+
+export default PressNewsModel;

--- a/newsstand/src/views/newsList/pressNews/pressNewsView.js
+++ b/newsstand/src/views/newsList/pressNews/pressNewsView.js
@@ -58,7 +58,7 @@ class PressNewsView {
             `).join('');
         }
 
-        newsComment.textContent = `${news.pressName} 언론사에서 직접 편집한 뉴스입니다.`;
+        newsComment.textContent = `${news.mediaName} 언론사에서 직접 편집한 뉴스입니다.`;
     }
 
     getElement() {

--- a/newsstand/src/views/newsList/pressNews/pressNewsView.js
+++ b/newsstand/src/views/newsList/pressNews/pressNewsView.js
@@ -1,0 +1,69 @@
+const CLASS = Object.freeze({
+    PRESS_NEWS_CONTAINER: 'press-news-container',
+    PRESS_MAIN_NEWS_CONTAINER: 'press-main-news-container',
+    PRESS_MAIN_NEWS_IMG: 'press-main-news-img',
+    PRESS_MAIN_NEWS_IMG_CONTAINER: 'press-main-news-img-container',
+    PRESS_MAIN_NEWS_TITLE: 'press-main-news-title',
+    PRESS_LIST_NEWS_CONTAINER: 'press-list-news-container',
+    PRESS_SUB_NEWS_LIST: 'press-sub-news-list',
+    PRESS_LIST_NEWS_COMMENT: 'press-list-news-comment'
+})
+
+export const IntervalKey = Object.freeze({
+    RollingLeft: 'RollingLeft',
+    RollingRight: 'RollingRight',
+    Progress: 'Progress'
+});
+
+class PressNewsView {
+    constructor() {
+        this.element = document.createElement('div');
+        this.element.className = CLASS.PRESS_NEWS_CONTAINER;
+
+        this.render();
+    }
+
+    render() {
+        const html = `
+            <div class="${CLASS.PRESS_MAIN_NEWS_CONTAINER}">
+                <div class="${CLASS.PRESS_MAIN_NEWS_CONTAINER}">
+                    <img class="${CLASS.PRESS_MAIN_NEWS_IMG}" src="" alt="Main news image"/>
+                </div>
+                <p class="${CLASS.PRESS_MAIN_NEWS_TITLE}"></p>
+            </div>
+            <div class="${CLASS.PRESS_LIST_NEWS_CONTAINER}">
+                <ul class="${CLASS.PRESS_SUB_NEWS_LIST}"></ul>
+                <span class="${CLASS.PRESS_LIST_NEWS_COMMENT}"></span>
+            </div>
+        `;
+
+        this.element.innerHTML = html;
+    }
+
+    update(news) {
+        const mainNewsImg = this.element.querySelector(`.${CLASS.PRESS_MAIN_NEWS_IMG}`);
+        const mainNewsTitle = this.element.querySelector(`.${CLASS.PRESS_MAIN_NEWS_TITLE}`);
+        const subNewsList = this.element.querySelector(`.${CLASS.PRESS_SUB_NEWS_LIST}`);
+        const newsComment = this.element.querySelector(`.${CLASS.PRESS_LIST_NEWS_COMMENT}`);
+
+        if (news.mainNews) {
+            mainNewsImg.src = news.mainNews.thumbnailImage;
+            mainNewsImg.alt = news.mainNews.newsTitle;
+            mainNewsTitle.textContent = news.mainNews.newsTitle;
+        }
+
+        if (news.subNews && Array.isArray(news.subNews)) {
+            subNewsList.innerHTML = news.subNews.map(n => `
+                <li>${n.newsTitle}</li>
+            `).join('');
+        }
+
+        newsComment.textContent = `${news.pressName} 언론사에서 직접 편집한 뉴스입니다.`;
+    }
+
+    getElement() {
+        return this.element;
+    }
+}
+
+export default PressNewsView;

--- a/newsstand/src/views/pressMenu/pressMenuController.js
+++ b/newsstand/src/views/pressMenu/pressMenuController.js
@@ -7,38 +7,28 @@ import DataManager from '../../manager/dataManager.js';
 class PressMenuController {
     constructor() {
         this.model = new PressMenuModel();
-        this.view = new PressMenuView();
+        this.view = new PressMenuView({ 
+            onClickSubscribeMenu: (value) => this.handleAllPress(value), 
+            onClickListMenu: (value) => this.handleListView(value)
+        });
 
         this.view.render();
 
-        this.handleToggleAllPress = this.handleToggleAllPress.bind(this);
-        this.handleToggleListView = this.handleToggleListView.bind(this);
-
-        this.view.addEventListenerToSubscribeButtons(this.handleToggleAllPress);
-        this.view.addEventListenerToListButtons(this.handleToggleListView);
-
-        globalState.subscribe(StateKey.isAllPress, (value) => this.updateModel(value));
-        globalState.subscribe(StateKey.isGridView, (value) => this.updateModel(value));
+        globalState.subscribe(StateKey.IS_ALLPRESS, (value) => this.updateModel(value));
+        globalState.subscribe(StateKey.IS_GRIDVIEW, (value) => this.updateModel(value));
     }
 
     updateModel(newState) {
         this.view.render();
-
-        // addEventListener 부분 수정하기
-        this.handleToggleAllPress = this.handleToggleAllPress.bind(this);
-        this.handleToggleListView = this.handleToggleListView.bind(this);
-
-        this.view.addEventListenerToSubscribeButtons(this.handleToggleAllPress);
-        this.view.addEventListenerToListButtons(this.handleToggleListView);
     }
 
-    handleToggleAllPress(isAllPress) {
+    handleAllPress(isAllPress) {
         this.model.setAllPress(isAllPress);
 
-        globalState.setState(StateKey.tabFields, isAllPress? DataManager.getAllPressTabs(): DataManager.getSubscribedPressTabs());
+        globalState.setState(StateKey.TABFIELDS, isAllPress? DataManager.getAllPressTabs(): DataManager.getSubscribedPressTabs());
     }
 
-    handleToggleListView(isListView) {
+    handleListView(isListView) {
         this.model.setGridView(isListView);
     }
 

--- a/newsstand/src/views/pressMenu/pressMenuController.js
+++ b/newsstand/src/views/pressMenu/pressMenuController.js
@@ -24,8 +24,6 @@ class PressMenuController {
 
     handleAllPress(isAllPress) {
         this.model.setAllPress(isAllPress);
-
-        globalState.setState(StateKey.TABFIELDS, isAllPress? DataManager.getAllPressTabs(): DataManager.getSubscribedPressTabs());
     }
 
     handleListView(isListView) {

--- a/newsstand/src/views/pressMenu/pressMenuController.js
+++ b/newsstand/src/views/pressMenu/pressMenuController.js
@@ -1,0 +1,50 @@
+import { StateKey } from '../../namespace/StateKey.js';
+import globalState from '../../app/GlobalState.js';
+import PressMenuModel from './pressMenuModel.js';
+import PressMenuView from './pressMenuView.js';
+import DataManager from '../../manager/dataManager.js';
+
+class PressMenuController {
+    constructor() {
+        this.model = new PressMenuModel();
+        this.view = new PressMenuView();
+
+        this.view.render();
+
+        this.handleToggleAllPress = this.handleToggleAllPress.bind(this);
+        this.handleToggleListView = this.handleToggleListView.bind(this);
+
+        this.view.addEventListenerToSubscribeButtons(this.handleToggleAllPress);
+        this.view.addEventListenerToListButtons(this.handleToggleListView);
+
+        globalState.subscribe(StateKey.isAllPress, (value) => this.updateModel(value));
+        globalState.subscribe(StateKey.isGridView, (value) => this.updateModel(value));
+    }
+
+    updateModel(newState) {
+        this.view.render();
+
+        // addEventListener 부분 수정하기
+        this.handleToggleAllPress = this.handleToggleAllPress.bind(this);
+        this.handleToggleListView = this.handleToggleListView.bind(this);
+
+        this.view.addEventListenerToSubscribeButtons(this.handleToggleAllPress);
+        this.view.addEventListenerToListButtons(this.handleToggleListView);
+    }
+
+    handleToggleAllPress(isAllPress) {
+        this.model.setAllPress(isAllPress);
+
+        globalState.setState(StateKey.tabFields, isAllPress? DataManager.getAllPressTabs(): DataManager.getSubscribedPressTabs());
+    }
+
+    handleToggleListView(isListView) {
+        this.model.setGridView(isListView);
+    }
+
+    getElement() {
+        return this.view.getElement();
+    }
+}
+
+export default PressMenuController;

--- a/newsstand/src/views/pressMenu/pressMenuModel.js
+++ b/newsstand/src/views/pressMenu/pressMenuModel.js
@@ -1,0 +1,29 @@
+import { StateKey } from "../../namespace/StateKey.js";
+import globalState from "./../../app/GlobalState.js";
+
+class PressMenuModel {
+    constructor() {
+        this.isAllPress = null;
+        this.isGrid = null;
+    }
+
+    getAllPress() {
+        return this.isAllPress;
+    }
+
+    setAllPress(isAllPress) {
+        this.isAllPress = isAllPress;
+        globalState.setState(StateKey.isAllPress, isAllPress);
+    }
+
+    getGrid() {
+        return this.isGrid;
+    }
+
+    setGridView(isGrid) {
+        this.isGrid = isGrid;
+        globalState.setState(StateKey.isGrid, isGrid);
+    }
+}
+
+export default PressMenuModel;

--- a/newsstand/src/views/pressMenu/pressMenuModel.js
+++ b/newsstand/src/views/pressMenu/pressMenuModel.js
@@ -13,7 +13,10 @@ class PressMenuModel {
 
     setAllPress(isAllPress) {
         this.isAllPress = isAllPress;
-        globalState.setState(StateKey.isAllPress, isAllPress);
+
+        globalState.setState(StateKey.IS_ALLPRESS, isAllPress);
+        globalState.setState(StateKey.SELECTED_CATEGORY_INDEX, 0);
+        globalState.setState(StateKey.SELECTED_CATEGORY_COUNT_INDEX, 0);
     }
 
     getGrid() {
@@ -22,6 +25,7 @@ class PressMenuModel {
 
     setGridView(isGrid) {
         this.isGrid = isGrid;
+
         globalState.setState(StateKey.isGrid, isGrid);
     }
 }

--- a/newsstand/src/views/pressMenu/pressMenuModel.js
+++ b/newsstand/src/views/pressMenu/pressMenuModel.js
@@ -15,6 +15,7 @@ class PressMenuModel {
         this.isAllPress = isAllPress;
 
         globalState.setState(StateKey.IS_ALLPRESS, isAllPress);
+        globalState.setState(StateKey.TABFIELDS, isAllPress? DataManager.getAllPressTabs(): DataManager.getSubscribedPressTabs());
         globalState.setState(StateKey.SELECTED_CATEGORY_INDEX, 0);
         globalState.setState(StateKey.SELECTED_CATEGORY_COUNT_INDEX, 0);
     }
@@ -26,7 +27,7 @@ class PressMenuModel {
     setGridView(isGrid) {
         this.isGrid = isGrid;
 
-        globalState.setState(StateKey.isGrid, isGrid);
+        globalState.setState(StateKey.IS_GRIDVIEW, isGrid);
     }
 }
 

--- a/newsstand/src/views/pressMenu/pressMenuView.js
+++ b/newsstand/src/views/pressMenu/pressMenuView.js
@@ -1,7 +1,9 @@
 class PressMenuView {
-    constructor() {
+    constructor({onClickSubscribeMenu, onClickListMenu}) {
         this.element = document.createElement('div');
         this.element.className = 'press-menu-container';
+        this.onClickSubscribeMenu = onClickSubscribeMenu;
+        this.onClickListMenu = onClickListMenu;
     }
 
     render() {
@@ -17,24 +19,26 @@ class PressMenuView {
         `;
 
         this.element.innerHTML = html;
+        this.addEventListenerToSubscribeButtons();
+        this.addEventListenerToListButtons();
     }
 
-    addEventListenerToSubscribeButtons(callback) {
+    addEventListenerToSubscribeButtons() {
         const subscribeButtons = this.element.querySelectorAll('.subscribe-menu-button');
 
         subscribeButtons.forEach(button => {
             button.addEventListener('click', (event) => {
-                callback(event.target.id === 'all-press');
+                this.onClickSubscribeMenu(event.target.id === 'all-press');
             });
         });
     }
 
-    addEventListenerToListButtons(callback) {
+    addEventListenerToListButtons() {
         const listGridButtons = this.element.querySelectorAll('.list-grid-button');
-        
+
         listGridButtons.forEach(button => {
             button.addEventListener('click', (event) => {
-                callback(event.target.id === 'list-view');
+                this.onClickListMenu(event.target.id === 'list-view');
             });
         });
     }

--- a/newsstand/src/views/pressMenu/pressMenuView.js
+++ b/newsstand/src/views/pressMenu/pressMenuView.js
@@ -1,20 +1,34 @@
+const CLASS = Object.freeze({
+    PRESS_MENU_CONTAINER: 'press-menu-container',
+    SUBSCRIBE_MENU_CONTAINER: 'subscribe-menu-container',
+    SUBSCRIBE_MENU_BUTTON: 'subscribe-menu-button',
+    LIST_GRID_BUTTON: 'list-grid-button'
+});
+
+const ID = Object.freeze({
+    ALL_PRESS: 'all-press',
+    SUBSCRIBED_PRESS: 'subscribed-press',
+    LIST_VIEW: 'list-view',
+    GRID_VIEW: 'grid-view'
+});
+
 class PressMenuView {
-    constructor({onClickSubscribeMenu, onClickListMenu}) {
+    constructor({ onClickSubscribeMenu, onClickListMenu }) {
         this.element = document.createElement('div');
-        this.element.className = 'press-menu-container';
+        this.element.className = CLASS.PRESS_MENU_CONTAINER;
         this.onClickSubscribeMenu = onClickSubscribeMenu;
         this.onClickListMenu = onClickListMenu;
     }
 
     render() {
         const html = `
-            <div class="subscribe-menu-container">
-                <button id="all-press" class="subscribe-menu-button">전체 언론사</button>
-                <button id="subscribed-press" class="subscribe-menu-button">내가 구독한 언론사</button>
+            <div class="${CLASS.SUBSCRIBE_MENU_CONTAINER}">
+                <button id="${ID.ALL_PRESS}" class="${CLASS.SUBSCRIBE_MENU_BUTTON}">전체 언론사</button>
+                <button id="${ID.SUBSCRIBED_PRESS}" class="${CLASS.SUBSCRIBE_MENU_BUTTON}">내가 구독한 언론사</button>
             </div>
             <div>
-                <img id="list-view" src="../../assets/icons/list-view.svg" alt="list view icon" class="list-grid-button">
-                <img id="grid-view" src="../../assets/icons/grid-view.svg" alt="grid view icon" class="list-grid-button">
+                <img id="${ID.LIST_VIEW}" src="../../assets/icons/list-view.svg" alt="list view icon" class="${CLASS.LIST_GRID_BUTTON}">
+                <img id="${ID.GRID_VIEW}" src="../../assets/icons/grid-view.svg" alt="grid view icon" class="${CLASS.LIST_GRID_BUTTON}">
             </div>
         `;
 
@@ -24,21 +38,21 @@ class PressMenuView {
     }
 
     addEventListenerToSubscribeButtons() {
-        const subscribeButtons = this.element.querySelectorAll('.subscribe-menu-button');
+        const subscribeButtons = this.element.querySelectorAll(`.${CLASS.SUBSCRIBE_MENU_BUTTON}`);
 
         subscribeButtons.forEach(button => {
             button.addEventListener('click', (event) => {
-                this.onClickSubscribeMenu(event.target.id === 'all-press');
+                this.onClickSubscribeMenu(event.target.id === ID.ALL_PRESS);
             });
         });
     }
 
     addEventListenerToListButtons() {
-        const listGridButtons = this.element.querySelectorAll('.list-grid-button');
+        const listGridButtons = this.element.querySelectorAll(`.${CLASS.LIST_GRID_BUTTON}`);
 
         listGridButtons.forEach(button => {
             button.addEventListener('click', (event) => {
-                this.onClickListMenu(event.target.id === 'list-view');
+                this.onClickListMenu(event.target.id === ID.LIST_VIEW);
             });
         });
     }

--- a/newsstand/src/views/pressMenu/pressMenuView.js
+++ b/newsstand/src/views/pressMenu/pressMenuView.js
@@ -1,0 +1,47 @@
+class PressMenuView {
+    constructor() {
+        this.element = document.createElement('div');
+        this.element.className = 'press-menu-container';
+    }
+
+    render() {
+        const html = `
+            <div class="subscribe-menu-container">
+                <button id="all-press" class="subscribe-menu-button">전체 언론사</button>
+                <button id="subscribed-press" class="subscribe-menu-button">내가 구독한 언론사</button>
+            </div>
+            <div>
+                <img id="list-view" src="../../assets/icons/list-view.svg" alt="list view icon" class="list-grid-button">
+                <img id="grid-view" src="../../assets/icons/grid-view.svg" alt="grid view icon" class="list-grid-button">
+            </div>
+        `;
+
+        this.element.innerHTML = html;
+    }
+
+    addEventListenerToSubscribeButtons(callback) {
+        const subscribeButtons = this.element.querySelectorAll('.subscribe-menu-button');
+
+        subscribeButtons.forEach(button => {
+            button.addEventListener('click', (event) => {
+                callback(event.target.id === 'all-press');
+            });
+        });
+    }
+
+    addEventListenerToListButtons(callback) {
+        const listGridButtons = this.element.querySelectorAll('.list-grid-button');
+        
+        listGridButtons.forEach(button => {
+            button.addEventListener('click', (event) => {
+                callback(event.target.id === 'list-view');
+            });
+        });
+    }
+
+    getElement() {
+        return this.element;
+    }
+}
+
+export default PressMenuView;


### PR DESCRIPTION
## ⁉️ 작업 내용
- 구독 시 화면 이동을 구현하려다 보니 state 설계의 필요성을 느끼고 global state를 추가하였습니다.
- 원래 해보고 싶었던 MVC Pattern을 적용하였습니다. (전체 적용은 어렵고, global state가 필요한 부분만 적용하도록 하였습니다.)



## 🔧 앞으로의 과제
- 저녁에 MVC 패턴 조금 더 마무리 하고, 구독 이동까지 구현할 예정입니다.


---


# Newsstand

## 1️⃣ COCOA MVC ?? 처럼 짜기

---

1주차에 어떻게 짰었는지.. 말해보자면 코코아 엠븨씨?! 처럼 하나의 컨트롤러에 모든걸 다 때려박는 .. 코딩을 했다. 뭐 패턴이라고 말도 할 수 없다..!!! MASSIVE CONTROLLER라고 들어봤나?! 그 길로 가는 중이었다.

`PressCategoryContainer`가 하나의 `class`라고 이해하고 그 안에 사용되는 `프로퍼티`, `메서드들을` 나열했다.

```jsx
// pressCategory.js
import { separateId } from "../../../utils/utils.js";

const PressCategoryContainer = ({ 
    isAllPress, 
    tabFields,
    selectedIndex,
    onChangeCategory,
    countInfo,
}) => {
    const element = document.createElement('div');
    element.className = 'press-category-container';

    let buttons = [];
    let progressBars = [];

    function onClickEvent(event) {
        const intId = separateId(event.target.id);
   
        onChangeCategory(intId);
    }

    function updateSelectedButtonStyle() {
        buttons.forEach((button, index) => {
            const isSelected = index === selectedIndex;
            button.className = isSelected ? 'press-category-button-selected' :'press-category-button';

            updateInfoSpanStyle(button, isSelected);
            updateProgressBarStyle(index, isSelected);
        });
    }

    function updateInfoSpanStyle(button, isSelected) {
        const infoSpan = button.querySelector('.press-count-span');
        if (infoSpan) {
            if (isAllPress) {
                infoSpan.textContent = isSelected ? `${countInfo}` : "";
            } else {
                infoSpan.textContent = ">"
            }
        }
    }

    function updateProgressBarStyle(index, isSelected) {
        if (isSelected) {
            progressBars[index].classList.add('selected');
        } else {
            progressBars[index].classList.remove('selected');
        }
    }

    function createButtonHTML(category, index) {
        return `
            <button class="press-category-button" id="press-category-${index}">
                <div class="press-category-button-progress" id="press-category-${index}"></div>
                <div class="press-category-span-container" id="press-category-${index}">
                    <span id="press-category-${index}">${category.tabName}</span>
                    <span id="press-category-${index}" class="press-count-span"></span>
                </div>
            </button>
        `;
    }
    
    function renderButtons() {
        let buttonsHTML = '';
        tabFields.forEach((category, index) => {
            buttonsHTML += createButtonHTML(category, index);
        });
    
        element.innerHTML = buttonsHTML;
    
        buttons = Array.from(element.querySelectorAll('.press-category-button'));
        progressBars = Array.from(element.querySelectorAll('.press-category-button-progress'));
    }
    

    function addEventListeners() {
        buttons.forEach(button => {
            button.addEventListener('click', onClickEvent);
        });
    }

    function render() {
        renderButtons();
        addEventListeners();
        updateSelectedButtonStyle();
    }

    render();

    return {
        element
    };
};

export default PressCategoryContainer;
```

**이렇게 하다 보니 넘겨야하는 `props`가 굉장히 많았고, 또 `다른 파일에 있는 변수`들에 영향을 주기가 어려웠다**.

예를 들면 [구독하기 ⇒ 토스트메세지 ⇒ 구독 탭으로 이동] 기능이 있었는데, 이 카테고리와 뉴스와 구독 탭 메뉴가  다 다른 파일에 있다보니까 영향을 줄 수 없었다.

가장 쉬운 방법은 다시 렌더링 되어야하는 부분만 `export function`으로 빼는 것이었는데, 뭔가 다른 클래스에 있는 메서드들을 모아서 사용한다는건 의존 관계에 있어서 굉장히 불필요하다고 느꼈다.

실제 클래스?는 아니지만 **뭔가 뷰들간의 관계, 의존성**을 잡고싶었다.

그리고 코드가 너무 길다고 생각했다. 물론 내가 함수를 따로 빼서 관리하지 않았고, 더 잘게 쪼개지 못 했으며 가독성이 떨어지는 코드를 짜서 그런 영향도 있겠지만 갈수록 읽기 힘드니까 이 로직과, 뷰, 데이터들을 따로 관리하고싶었다. 그래서 `MVC PATTERN`을 채택하였다.

이전에도 하고싶었는데 클래스를 쓰지 말라하셔서, 클래스 없이는 이해가 가지 않아 도전을 안 하고 구상만 했었는데, 클래스를 써도 된다는 말에 냅다 시작했다.

## 2️⃣ MVC PATTERN 적용해보기

---

### ⁉️ Controller ⁉️

**`controller`에서 `view`와 `model`을 생성하고 . 그 사이를 조율하는게 `controller`의 역할이었다.**

view를 랜더링 시켜 html 파일을 그리고, updateModel()을 하면서 초기값을 가져와 동적 컨텐츠 - 텍스트, 이미지 소스 등을 넣어주었다.

그래서 만약 model의 값이 바뀌어야 한다면, **즉 외부 이벤트로 인해 값이 바뀐다면 그걸 컨트롤러가 받고, 모델에 전달해줘서, 그 모델 데이터로 뷰를 다시 그리는 느낌으로 개발하고싶었다**

~~( 아래 코드는 동작하지 않을 수 있다… 나중에 설명하고싶은 부분은 뺏으니..)~~

```jsx
class PressCategoryController {
    constructor() {
        this.model = new PressCategoryModel();
        this.view = new PressCategoryView({
            onClickCategory: (id) => { this.onChangeCategory(id); }
        });

        this.render();

        this.updateModel(); 
    }

    updateModel(key, value) {
        if (key) {
            this.model.setState({ [key]: value });
        }

        const newState = this.model.getState();
        this.view.update(newState);
    }

    render() {
        this.view.render();
    }

    onChangeCategory(intId) {
        this.model.setSelectedIndex(intId);
    }

    getElement() {
        return this.view.getElement();
    }
}

export default PressCategoryController;
```

### ⁉️ view ⁉️

사실 원래 컨테이너에 있는 내용 대부분이 style과 관련되었기 때문에 뷰 자체의 내용이 줄어들진 않았다.

그래서 지금 예시를 보여주자니 뷰 하나가 컨트롤러, 뷰. 모델로 쪼개지면서 코드가 3배로 늘어난 것 같은 느낌이 든다 ^^…😂

근데 중요하게 볼 부분은 **props 설정 부분**이다. **아까 container에서는 5개 정도의 파라미터를 넘기는 것을 볼 수 있었는데, 지금은 onClickCategory 단 하나를 넘기게 되었다.**

~~날 괴롭히던 초기값,,,그리고 부모와의 관계를 떼어놓을 수 있었다.~~

```jsx

class PressCategoryView {
    constructor({ onClickCategory }) {
        this.element = document.createElement('div');
        this.element.className = CLASS.PRESS_CATEGORY_CONTAINER;
        this.categoryClickCallback = onClickCategory;
    }

    render() {
        this.element.innerHTML = '';
    }

    update({ tabFields, selectedCategoryIndex, isAllPress, countInfo }) {
        this.element.innerHTML = this.createButtonHTML(tabFields);
        this.attachButtonListeners();
        this.updateSelectedButtonStyle(selectedCategoryIndex, countInfo, isAllPress);
    }

    attachButtonListeners() {
        const buttons = this.element.querySelectorAll(`.${CLASS.PRESS_CATEGORY_BUTTON}`);

        buttons.forEach(button => {
            button.addEventListener('click', () => {
                const intId = separateId(button.id);
                this.categoryClickCallback(intId);
            });
        });
    }

    createButtonHTML(tabFields) {
        let buttonsHTML = '';
        tabFields.forEach((category, index) => {
            buttonsHTML += `
                <button class="${CLASS.PRESS_CATEGORY_BUTTON}" id="press-category-${index}">
                    <div class="${CLASS.PRESS_CATEGORY_BUTTON_PROGRESS}"></div>
                    <div class="${CLASS.PRESS_CATEGORY_SPAN_CONTAINER}">
                        <span>${category.tabName}</span>
                        <span class="${CLASS.PRESS_COUNT_SPAN}"></span>
                    </div>
                </button>
            `;
        });
        return buttonsHTML;
    }

    updateSelectedButtonStyle(selectedIndex, countInfo, isAllPress) {
        const buttons = this.element.querySelectorAll(`.${CLASS.PRESS_CATEGORY_BUTTON}`);

        buttons.forEach((button, index) => {
            const isSelected = index === selectedIndex;
            button.className = isSelected ? CLASS.PRESS_CATEGORY_BUTTON_SELECTED : CLASS.PRESS_CATEGORY_BUTTON;
            this.updateInfoSpanStyle(button, isSelected, countInfo, isAllPress);
            this.updateProgressBarStyle(button, isSelected);
        });
    }

    updateProgressBarStyle(button, isSelected) {
        const progressBar = button.querySelector(`.${CLASS.PRESS_CATEGORY_BUTTON_PROGRESS}`);
        if (isSelected) {
            progressBar.classList.add(CLASS.SELECTED);
        } else {
            progressBar.classList.remove(CLASS.SELECTED);
        }
    }

    updateInfoSpanStyle(button, isSelected, countInfo, isAllPress) {
        const infoSpan = button.querySelector(`.${CLASS.PRESS_COUNT_SPAN}`);
        if (infoSpan) {
            if (isAllPress) {
                infoSpan.textContent = isSelected ? `${countInfo}` : "";
            } else {
                infoSpan.textContent = isSelected ? ">" : "";
            }
        }
    }

    getElement() {
        return this.element;
    }
}

export default PressCategoryView;
```

### ⁉️  model ⁉️

view에 넘어갈 **데이터**들이 model에서 관리되고 있다고 보면 될 것 같다.

기본적으로 모든 모델은 **getState와 setState를 지니고 있어, 직접 state에 접근하지 못 하게 막아두었다.**

이외에 필요한 set, get 함수들은 필요한 경우에만 생성하였다.

```jsx
class PressCategoryModel {
    constructor() {
        this.state = {
            isAllPress:,
            tabFields: ,
            selectedCategoryIndex: ,
            selectedCategoryCountIndex: ,
            countInfo: ''
        };

        this.setCountInfo()
    }

    setCountInfo() {
        this.state.countInfo = `${this.state.selectedCategoryCountIndex + 1}/${this.state.tabFields[this.state.selectedCategoryIndex].tabData.length}`;
    }

    getState() {
        return this.state;
    }

    setState(newState) {
        this.state = { ...this.state, ...newState };
        this.setCountInfo();
    }

    setSelectedIndex(index) {
        this.setState({ selectedCategoryIndex: index });
        this.setState({ selectedCategoryCountIndex: 0 });
    }
}

export default PressCategoryModel;

```

너무 코드만 줄줄인데, 다시 본론으로 넘어와 문제점을 짚어보자.

**이렇게 하다 보니 넘겨야하는 props가 굉장히 많았고, 또 다른 파일에 있는 변수들에 영향을 주기가 어려웠다.**

이게 문제였지 않나, 이 중에 하나인 props가 해결이 되었다면, 다른 파일에 있는 변수 영향은 어떻게 주면 될까?

이건 강사님의 말에 해답이 있었다. 내가 하고싶었고 고민하고싶었던 부분이 강사님의 말에 해결책을 얻었고 바로 구현될 수 있었다. ~~물론 GPT가 많이 도와줬다.~~

## 3️⃣ 글로벌 스테이트 이용하기

---

결국엔 **글로벌 스테이트를 만들 수 밖에 없지 않나?** 라고 결론을 내렸다.

이거 가지고 조원들하고 열심히 토론해보았지만, 다들 어떻게든 **전역적으로** 이용하는 느낌이었다.

그러면 그냥 나도 전역으로 쓰자.. 해서 생각해낸게 글로벌 스테이트였다.

진짜 거창한게 아니라, 그냥 스테이트를 모아둔게 다 였다.

**글로벌 스테이트에 내가 사용할 값들을 정해두고, get , set, subscribe를 만들었다.**

- state: 진짜 state, 음.. 데이터?.. 어떤 변수값..? 이라고 생각하면 될 것 같다.
- listeners: 구독에서 사용되는데, 구독시에 이 listener를 같이 넘겨줘서, **state가 변경이 되면 ⇒ listener를 실행하게 된다.**

setState() 함수를 보면 state를 변경시킨 이후에, notifyListeners를 호출하게 된다.

notifyListeners는 그 state와 연결 된 listener를 찾아서 listener를 한 번씩 호출시키는 과정을 가진다.

강사님의 말을 기억하시는 분?!

실행시킬 함수 자체를 파라미터로 넘기라고 했다. 그게 이 listener이다!!

```jsx
class GlobalState {
    constructor() {
        this.state = {
            isAllPress: true,
            isGridView: true,
            tabFields: DataManager.getAllPressTabs(),
            selectedCategoryIndex: 0,
            selectedCategoryCountIndex: 0
        };
        this.listeners = {};
    }

    getState(key) {
        return this.state[key];
    }

    setState(key, value) {
        this.state[key] = value;
        this.notifyListeners(key, value);
    }

    subscribe(key, listener) {
        if (!this.listeners[key]) {
            this.listeners[key] = [];
        }
        this.listeners[key].push(listener);
    }

    notifyListeners(key, value) {
        if (!this.listeners[key]) return;
        this.listeners[key].forEach(listener => {
            listener(value)
        });
    }
}

const globalState = new GlobalState();
export default globalState;
```

자 블로그와 지피티로 1차 가다듬고, 내가 원하는대로 쓱 수정까지 했다. 그럼 이걸 이제 쓰면 된다!

**이걸 MVC에 어떻게 적용하면 좋을까?** 를 정말 많이 고민해 본 것 같다.

맞는 방법이라고 장담할 수는 없지만, 나는 이렇게 했다.

controller에서는 subscribe를

model에서는 set을

view에서는 아예 모르게,, 음… 조금 더 구체적으로 보자.

### controller - 생성자

---

생성자 내에 단 한 번의 **구독을 실행**한다.

그러면 **StateKey와 UpdateModel이 global State로 넘어가게 된다.**

이제 StateKey가 바뀐다면, updateModel이 자동으로 실행 된다. ⇒ **다른 파일에서 setState로 값을 바꿔도 이 파일에서 실행이 될 수 있다는 것이다.**

```jsx
  globalState.subscribe(StateKey.IS_ALLPRESS, (value) => {
      this.updateModel(StateKey.IS_ALLPRESS, value);
  });

  globalState.subscribe(StateKey.TABFIELDS, (value) => {
      this.updateModel(StateKey.TABFIELDS, value);
  });

  globalState.subscribe(StateKey.SELECTED_CATEGORY_INDEX, (value) => {
      this.updateModel(StateKey.SELECTED_CATEGORY_INDEX, value);
  });

  globalState.subscribe(StateKey.SELECTED_CATEGORY_COUNT_INDEX, (value) => {
      this.updateModel(StateKey.SELECTED_CATEGORY_COUNT_INDEX, value);
  });
```

### controller - updateModel

---

여기서 바로 model.setState 안하고 globalState.set해도 된다.

근데 그러면 model이 너무 쓸모없지 않나..? 거의 없어도 되는 역할이 되길래 나는 **model로 setState를 넘겨주었다.** 

그러면 **model로 넘어가서 model의 state 값을 변경시켜주고, 그 이후에 model의 state 값을 가지고 view를 update 시켜준다.**

```jsx
updateModel(key, value) {
    if (key) {
        this.model.setState({ [key]: value });
    }

    const newState = this.model.getState();
    this.view.update(newState);
}
```

### model - global set State

---

**모델이 controller로 부터 받은 state를 가지고, 자기 자신의 state도 업데이트해주면서, global state도 업데이트 시켜준다.**

이 global state를 업데이트 시켜주는게, controller의 역할인지… model의 역할인지는 잘 모르겠다.

아마 controller 아닐까? 싶은데… 내가 모델에서 한 이유는 컨트롤러에서 하면 업데이트 받고 스테이트 받고 업데이트 또 하고 이런 느낌이 들어서 모델에서 하기로 했다. ~~(근데 뭐 그게 그거 아닌강? ㅎ ㅜ…)~~

```jsx
this.setState({ selectedCategoryIndex: index });
this.setState({ selectedCategoryCountIndex: 0 });
        
globalState.setState(StateKey.SELECTED_CATEGORY_INDEX, index);
globalState.setState(StateKey.SELECTED_CATEGORY_COUNT_INDEX, 0);
```

## 결론

 이 관련 파일들이 이 아래 사진을 위한 코드였다.

<img width="580" alt="Untitled" src="https://github.com/user-attachments/assets/e610f161-00f9-4c9e-b4e7-19e464a14fdc">

여기가 좀 복잡하져 여러분?! 나만 그런건 아니잖아~ 

아무튼. 이게 로직이 20초가 지나도 다음으로 넘어가야하고, arrow 버튼을 눌러도 다음으로 넘어가야 한다.

또 전체보기/구독보기 버튼에 따라서도 바뀌어야 한다.

아 너무 잘게 쪼개서 관리를 못 하겠는 분들은 저처럼 global state를 도입하자.

이제 arrow로 넘겨도(다른 파일에서 selectedIndex를 바꿔버려도), 컨트롤러 - 구독에서 넘긴 updateModel이 실행이 된다.

나는 좀 아쉬운 부분이 있다면, 이 바뀌는 state 값들을 하나의 `stream`으로 관리해보고싶다.

그게 무슨 말이냐면, 지금 코드만 봐도 setState를 2개를 하는데, 이러면 업데이트가 2번 된다. 즉 이 state를 두 개 다 구독한 컨트롤러가 있다면 두 번 렌더링 되는 것 이다.

그래서 이 두 개를 묶어서 state를 변경하고, subscribe 할 때도 두 개를 묶어서 할 수 있는 방법이 있지 않을까? 싶다. 이거는 내가 좀… 상태 관리 라이브러리들을 파악해봐야하지 않을까….해서 아쉬움으로 남겨두었다.


