### PR TITLE
[이태혁] FEAT: ProgressBar 구현

### DIFF
--- a/asset/icons/arrow.svg
+++ b/asset/icons/arrow.svg
@@ -1,0 +1,3 @@
+<svg width="5" height="8" viewBox="0 0 5 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.48317 7.5L0.666504 6.68333L3.34984 4L0.666504 1.31667L1.48317 0.5L4.98317 4L1.48317 7.5Z" fill="white"/>
+</svg>

--- a/components/fieldTab/fieldTab.js
+++ b/components/fieldTab/fieldTab.js
@@ -3,6 +3,7 @@ import { brandData } from "../../data/brandData.js";
 import { getSubscribeList } from "../../util/getSubscribeList.js";
 import { allNews } from "../news/allNews/allNews.js";
 import { subscribeNews } from "../news/subscriptionNews/subscriptionNews.js";
+import { renderProgressBar } from "./progressBar.js";
 
 /**
  *
@@ -58,6 +59,7 @@ const renderAllFieldTab = (fieldTab) => {
        newsData.data.length
      }</span>
     </div>
+    <div class="progress-bar hidden"></div>
   </button>`,
     ""
   );
@@ -78,6 +80,11 @@ const renderSubscribeFieldTab = (fieldTab) => {
         brandIdx === 0 ? "active" : ""
       }" data-brand-idx=${brandIdx} data-brand-id=${Number(brandId)}>
         ${brandData[brandId].brandName}
+        <img src = "../asset/icons/arrow.svg" class = "arrow ${
+          brandIdx === 0 ? "" : "hidden"
+        }" ></img>
+        <div class="progress-bar hidden"></div>
+
       </button>
     `;
     fieldTab.innerHTML += fieldTabBtn;
@@ -107,6 +114,8 @@ const handleClickAllField = (event) => {
 
   // 선택된 언론사 뉴스 렌더링
   allNews(btn.dataset.cateIdx, btn.dataset.brandIdx);
+
+  renderProgressBar();
 };
 
 const handleClickSubscribeField = (event) => {
@@ -116,11 +125,17 @@ const handleClickSubscribeField = (event) => {
   // 모든 버튼에서 active 클래스 제거
   document.querySelectorAll(".field-tab-btn").forEach((btn) => {
     btn.classList.remove("active");
+    btn.querySelector(".arrow").classList.add("hidden");
   });
 
   // 클릭된 버튼에 active 클래스 추가
   btn.classList.add("active");
 
+  // 화살표 아이콘 hidden 처리
+  btn.querySelector(".arrow").classList.remove("hidden");
+
   // 선택된 언론사 뉴스 렌더링
   subscribeNews(btn.dataset.brandIdx);
+
+  renderProgressBar();
 };

--- a/components/fieldTab/progressBar.js
+++ b/components/fieldTab/progressBar.js
@@ -1,0 +1,36 @@
+import { allSwipe, handleClickAllRightBtn } from "../swipe/allSwipe.js";
+import { handleClickSubscribeRightBtn } from "../swipe/subscriptionSwipe.js";
+
+let intervalId;
+
+export const renderProgressBar = () => {
+  stopProgress();
+
+  const progressBar = document.querySelector(
+    ".field-tab-btn.active .progress-bar"
+  );
+
+  Array.from(document.querySelectorAll(".progress-bar")).map((it) =>
+    it.classList.add("hidden")
+  );
+
+  progressBar.classList.remove("hidden");
+
+  let width = 0;
+  const duration = 2;
+  const interval = 20;
+  intervalId = setInterval(() => {
+    width += (interval / (duration * 1000)) * 100;
+    progressBar.style.width = width + "%";
+
+    if (width >= 100) {
+      if (
+        document.querySelector(".tab-and-viewer").dataset.tab === "subscription"
+      )
+        handleClickSubscribeRightBtn();
+      else handleClickAllRightBtn();
+    }
+  }, interval);
+};
+
+export const stopProgress = () => clearInterval(intervalId);

--- a/components/fieldTab/style.css
+++ b/components/fieldTab/style.css
@@ -2,9 +2,11 @@
   border-bottom: 1px solid var(--border-default);
 
   .field-tab-btn {
+    position: relative;
     padding: 11.5px 16px;
     display: inline-flex;
     align-items: center;
+    z-index: 1;
 
     &.active {
       font-size: 14px;
@@ -13,8 +15,19 @@
       color: var(--text-white-default);
     }
 
-    .brand-page-wrap {
+    .brand-page-wrap,
+    .arrow {
       margin-left: 80px;
+    }
+
+    .progress-bar {
+      position: absolute;
+      background-color: var(--surface-brand-default);
+      width: 0%;
+      height: 100%;
+      left: 0;
+      top: 0;
+      z-index: -1;
     }
   }
 }

--- a/components/rollingBar/rollingBar.js
+++ b/components/rollingBar/rollingBar.js
@@ -1,0 +1,29 @@
+import { currentNewsData } from "../../data/currentNewsData.js";
+
+export const renderRollingBar = () => {
+  const currentNews1 = document.querySelector(".current-news-1");
+  const currentNews2 = document.querySelector(".current-news-2");
+  console.log(currentNewsData[0]);
+
+  // currentNews들을 원래 위치로 이동
+
+  // 에니메이션 작동
+  animateRolling(currentNews1, currentNews2);
+
+  // 5초 딜레이
+  for (let i = 0; i < currentNewsData[0].news.length; i++) {
+    let currentNews = currentNewsData[0].news;
+    currentNews1.innerHTML = currentNews[i].title;
+    currentNews2.innerHTML = currentNews[i + 1].title;
+    console.log(123);
+    setTimeout(() => {}, 1200);
+  }
+};
+
+/**
+ * currentNews들을 이동시키는 함수
+ */
+const animateRolling = (currentNews1, currentNews2) => {
+  currentNews1.classList.add("roll");
+  currentNews2.classList.add("roll");
+};

--- a/components/rollingBar/rollingBar.js
+++ b/components/rollingBar/rollingBar.js
@@ -1,29 +1,99 @@
 import { currentNewsData } from "../../data/currentNewsData.js";
 
-export const renderRollingBar = () => {
-  const currentNews1 = document.querySelector(".current-news-1");
-  const currentNews2 = document.querySelector(".current-news-2");
-  console.log(currentNewsData[0]);
+/**
+ * 1초 간격으로 롤링바를 초기화하는 함수
+ */
+export const initRollingBar = () => {
+  // 첫 렌더링 시에도 뉴스가 보이도록 초기화
 
-  // currentNews들을 원래 위치로 이동
+  Array.from(document.querySelectorAll(".current-news-1")).map(
+    (currentNewsBox, idx) =>
+      renderCurrentNews(currentNewsBox, currentNewsData[idx][0])
+  );
+  Array.from(document.querySelectorAll(".current-news-2")).map(
+    (currentNewsBox, idx) =>
+      renderCurrentNews(currentNewsBox, currentNewsData[idx][0])
+  );
 
-  // 에니메이션 작동
-  animateRolling(currentNews1, currentNews2);
+  const a = document.querySelectorAll(".current-news-2")[0];
+  renderCurrentNews(a, currentNewsData[0][0]);
 
-  // 5초 딜레이
-  for (let i = 0; i < currentNewsData[0].news.length; i++) {
-    let currentNews = currentNewsData[0].news;
-    currentNews1.innerHTML = currentNews[i].title;
-    currentNews2.innerHTML = currentNews[i + 1].title;
-    console.log(123);
-    setTimeout(() => {}, 1200);
-  }
+  // 간격을 두고 롤링 시작
+  renderRollingBar(0);
+
+  setTimeout(() => {
+    renderRollingBar(1);
+  }, 1000);
 };
 
 /**
- * currentNews들을 이동시키는 함수
+ * rollingBarIdx 번째 롤링바 렌더링
+ *
+ * @param {number} rollingBarIdx
  */
-const animateRolling = (currentNews1, currentNews2) => {
-  currentNews1.classList.add("roll");
-  currentNews2.classList.add("roll");
+const renderRollingBar = (rollingBarIdx) => {
+  const currentNewsBox1 =
+    document.querySelectorAll(".current-news-1")[rollingBarIdx];
+  const currentNewsBox2 =
+    document.querySelectorAll(".current-news-2")[rollingBarIdx];
+  let newsData = currentNewsData[rollingBarIdx];
+
+  let i = 0;
+  let intervalId;
+
+  const startInterval = () => {
+    intervalId = setInterval(
+      () => setCurrentNews(i++, currentNewsBox1, currentNewsBox2, newsData),
+      2000
+    );
+  };
+
+  const stopInterval = () => {
+    clearInterval(intervalId);
+  };
+
+  startInterval();
+
+  // hover 이벤트 리스너 부착
+  currentNewsBox1.addEventListener("mouseenter", stopInterval);
+  currentNewsBox1.addEventListener("mouseleave", startInterval);
+  currentNewsBox2.addEventListener("mouseenter", stopInterval);
+  currentNewsBox2.addEventListener("mouseleave", startInterval);
+};
+
+/**
+ * 최신 뉴스를 위로 롤링시키는 함수
+ */
+const animateRolling = (currentNewsBox1, currentNewsBox2) => {
+  currentNewsBox1.classList.remove("roll");
+  currentNewsBox2.classList.remove("roll");
+
+  // roll 클래스 제거를 html에 적용시키기 위함
+  currentNewsBox1.offsetWidth;
+  currentNewsBox2.offsetWidth;
+
+  currentNewsBox1.classList.add("roll");
+  currentNewsBox2.classList.add("roll");
+};
+
+/**
+ * RollingBar에 뉴스 데이터를 넣어주고 애니메이션 호출
+ */
+const setCurrentNews = (i, currentNewsBox1, currentNewsBox2, newsData) => {
+  let [idx1, idx2] = [i % newsData.length, (i + 1) % newsData.length];
+
+  renderCurrentNews(currentNewsBox1, newsData[idx1]);
+  renderCurrentNews(currentNewsBox2, newsData[idx2]);
+
+  animateRolling(currentNewsBox1, currentNewsBox2);
+};
+
+/**
+ *
+ * a태그 생성
+ * @param {HTMLDivElement} currentNewsBox 최신 뉴스 텍스트를 감싸고있는 div박스
+ * @param {{title : stirng, url : string}} newsData
+ */
+const renderCurrentNews = (currentNewsBox, newsData) => {
+  currentNewsBox.innerHTML = `<a class = "available-medium14 text-default" href = ${newsData.url}>${newsData.title}</a>`;
 };

--- a/components/rollingBar/style.css
+++ b/components/rollingBar/style.css
@@ -1,23 +1,66 @@
 .rolling-bar {
   height: 49px;
   width: 100%;
+  position: relative;
+  overflow: hidden;
+
+  .current-news-1,
+  .current-news-2 {
+    position: absolute;
+    height: fit-content;
+    cursor: pointer;
+    width: 100%;
+
+    > a {
+      display: block;
+      width: 80%;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      word-break: break-all;
+
+      &:hover {
+        text-decoration: underline;
+        color: var(--text-bold);
+      }
+    }
+  }
 
   .current-news-1 {
-    position: absolute;
     top: 50%;
     transform: translateY(-50%);
 
-    &.rolld {
-      transition: all 0.5s;
-      transform: translateY(0);
+    &.roll {
+      animation: rolling1 0.5s forwards;
     }
   }
   .current-news-2 {
+    bottom: 0;
     transform: translateY(100%);
-
-    &.rolld {
-      transition: all 0.5s;
-      transform: translateY(-100%);
+    &.roll {
+      animation: rolling2 0.5s forwards;
     }
+  }
+}
+
+@keyframes rolling1 {
+  0% {
+    bottom: 50%;
+    transform: translateY(-50%);
+  }
+  100% {
+    top: 0%;
+    transform: translateY(-100%);
+  }
+}
+
+@keyframes rolling2 {
+  0% {
+    bottom: 0;
+    transform: translateY(100%);
+  }
+  100% {
+    top: 50%;
+    transform: translateY(-50%);
   }
 }

--- a/components/rollingBar/style.css
+++ b/components/rollingBar/style.css
@@ -1,0 +1,23 @@
+.rolling-bar {
+  height: 49px;
+  width: 100%;
+
+  .current-news-1 {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+
+    &.rolld {
+      transition: all 0.5s;
+      transform: translateY(0);
+    }
+  }
+  .current-news-2 {
+    transform: translateY(100%);
+
+    &.rolld {
+      transition: all 0.5s;
+      transform: translateY(-100%);
+    }
+  }
+}

--- a/components/subscriptionSwitchBtn/subscriptionSwitchBtn.js
+++ b/components/subscriptionSwitchBtn/subscriptionSwitchBtn.js
@@ -1,4 +1,5 @@
 import { fieldTab } from "../fieldTab/fieldTab.js";
+import { stopProgress } from "../fieldTab/progressBar.js";
 import { allSwipe } from "../swipe/allSwipe.js";
 import { subscribeSwipe } from "../swipe/subscriptionSwipe.js";
 
@@ -7,23 +8,38 @@ export const subscribeSwitchBtn = () => {
   const subscribeBrandTabBtn = document.querySelector(
     ".subscribe-brand-tab-btn"
   );
+  const tabAndViewer = document.querySelector(".tab-and-viewer");
 
   allBrandTabBtn.addEventListener("click", () =>
-    handleClickAllBrandTabBtn(allBrandTabBtn, subscribeBrandTabBtn)
+    handleClickAllBrandTabBtn(
+      tabAndViewer,
+      allBrandTabBtn,
+      subscribeBrandTabBtn
+    )
   );
 
   subscribeBrandTabBtn.addEventListener("click", () =>
-    handleClickSubscribeBrandTabBtn(allBrandTabBtn, subscribeBrandTabBtn)
+    handleClickSubscribeBrandTabBtn(
+      tabAndViewer,
+      allBrandTabBtn,
+      subscribeBrandTabBtn
+    )
   );
 
   // 페이지가 처음 렌더링될 때 allBrandTabBtn 클릭 이벤트 핸들러를 호출하여 기본값 설정
   allBrandTabBtn.click();
 };
 
-const handleClickAllBrandTabBtn = (allBrandTabBtn, subscribeBrandTabBtn) => {
+const handleClickAllBrandTabBtn = (
+  tabAndViewer,
+  allBrandTabBtn,
+  subscribeBrandTabBtn
+) => {
   // 전체 언론사 버튼이 굵어져야 함
   subscribeBrandTabBtn.classList.remove("active");
   allBrandTabBtn.classList.add("active");
+
+  tabAndViewer.dataset.tab = "all";
 
   // 전체 언론사 탭 버튼 렌더링
   fieldTab("allTabPress");
@@ -33,12 +49,14 @@ const handleClickAllBrandTabBtn = (allBrandTabBtn, subscribeBrandTabBtn) => {
 };
 
 const handleClickSubscribeBrandTabBtn = (
+  tabAndViewer,
   allBrandTabBtn,
   subscribeBrandTabBtn
 ) => {
   // 내가 구독한 언론사 버튼이 굵어져야 함
   allBrandTabBtn.classList.remove("active");
   subscribeBrandTabBtn.classList.add("active");
+  tabAndViewer.dataset.tab = "subscription";
 
   // 구독한 언론사 탭 버튼 렌더링
   fieldTab("subscribeTabPress");

--- a/components/swipe/allSwipe.js
+++ b/components/swipe/allSwipe.js
@@ -6,6 +6,7 @@ import {
   handleClickSubscribeLeftBtn,
   handleClickSubscribeRightBtn,
 } from "./subscriptionSwipe.js";
+import { renderProgressBar } from "../fieldTab/progressBar.js";
 
 // 전체 언론사 탭에서의 스와이프
 export const allSwipe = () => {
@@ -40,6 +41,9 @@ export const handleClickAllLeftBtn = () => {
 
   // 뉴스 렌더링
   allNews(prevCateIdx, prevBrandIdx);
+
+  // progressBar 다시 실행
+  renderProgressBar();
 };
 
 export const handleClickAllRightBtn = () => {
@@ -62,6 +66,9 @@ export const handleClickAllRightBtn = () => {
 
   // 뉴스 렌더링
   allNews(nextCateIdx, nextBrandIdx);
+
+  // progressBar 다시 실행
+  renderProgressBar();
 };
 
 // left swipe 시 다음 페이지의 cateIdx, brandIdx를 반환
@@ -110,7 +117,6 @@ const updateBrandPageWrap = (
   // 이전에 active 였던 tab -> hidden
   let curBrandPageWrap =
     fieldTabBtns[curCateIdx].querySelector(".brand-page-wrap");
-  let curBrandPage = curBrandPageWrap.querySelector(".cur-brand-page");
 
   let followingBrandPageWrap =
     fieldTabBtns[followingCateIdx].querySelector(".brand-page-wrap");

--- a/components/swipe/subscriptionSwipe.js
+++ b/components/swipe/subscriptionSwipe.js
@@ -1,5 +1,6 @@
 import { brandData } from "../../data/brandData.js";
 import { getSubscribeList } from "../../util/getSubscribeList.js";
+import { renderProgressBar } from "../fieldTab/progressBar.js";
 import { subscribeNews } from "../news/subscriptionNews/subscriptionNews.js";
 import { handleClickAllLeftBtn, handleClickAllRightBtn } from "./allSwipe.js";
 
@@ -36,8 +37,12 @@ export const handleClickSubscribeLeftBtn = () => {
   fieldTabBtns[curBrandIdx].classList.remove("active");
   fieldTabBtns[prevBrandIdx].classList.add("active");
 
+  updateArrowIcon(fieldTabBtns, curBrandIdx, prevBrandIdx);
+
   // 뉴스 렌더링
   subscribeNews(prevBrandIdx);
+
+  renderProgressBar();
 };
 
 export const handleClickSubscribeRightBtn = () => {
@@ -54,13 +59,26 @@ export const handleClickSubscribeRightBtn = () => {
   let curBrandIdx = Number(brandIdx);
 
   // 스와이프 한 후의 페이지를 계산
-  let prevBrandIdx =
+  let nextBrandIdx =
     curBrandIdx === subscribeList.length - 1 ? 0 : curBrandIdx + 1;
 
   // 필드 버튼 active 처리
   fieldTabBtns[curBrandIdx].classList.remove("active");
-  fieldTabBtns[prevBrandIdx].classList.add("active");
+  fieldTabBtns[nextBrandIdx].classList.add("active");
+
+  updateArrowIcon(fieldTabBtns, curBrandIdx, nextBrandIdx);
 
   // 뉴스 렌더링
-  subscribeNews(prevBrandIdx);
+  subscribeNews(nextBrandIdx);
+
+  renderProgressBar();
+};
+
+const updateArrowIcon = (fieldTabBtns, curBrandIdx, followingBrandIdx) => {
+  let curArrow = fieldTabBtns[curBrandIdx].querySelector(".arrow");
+  let followingArrow = fieldTabBtns[followingBrandIdx].querySelector(".arrow");
+
+  // 카테고리가 변했다면 hidden 처리
+  curArrow.classList.add("hidden");
+  followingArrow.classList.remove("hidden");
 };

--- a/data/currentNewsData.js
+++ b/data/currentNewsData.js
@@ -1,0 +1,102 @@
+export const currentNewsData = [
+  {
+    brandId: 0,
+    brandName: "서울경제",
+    news: [
+      {
+        title:
+          "0 송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
+        url: "https://m.entertain.naver.com/article/144/0000973128",
+      },
+      {
+        title: '1 전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
+        url: "https://m.entertain.naver.com/article/144/0000973129",
+      },
+      {
+        title:
+          "2 송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
+        url: "https://m.entertain.naver.com/article/144/0000973128",
+      },
+      {
+        title: '" 3전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
+        url: "https://m.entertain.naver.com/article/144/0000973129",
+      },
+      {
+        title:
+          " 4송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
+        url: "https://m.entertain.naver.com/article/144/0000973128",
+      },
+      {
+        title: '" 5전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
+        url: "https://m.entertain.naver.com/article/144/0000973129",
+      },
+    ],
+  },
+
+  {
+    brandId: 1,
+    brandName: "데일리안",
+    news: [
+      {
+        title:
+          "0 송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
+        url: "https://m.entertain.naver.com/article/144/0000973128",
+      },
+      {
+        title: '1 전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
+        url: "https://m.entertain.naver.com/article/144/0000973129",
+      },
+      {
+        title:
+          "2 송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
+        url: "https://m.entertain.naver.com/article/144/0000973128",
+      },
+      {
+        title: '" 3전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
+        url: "https://m.entertain.naver.com/article/144/0000973129",
+      },
+      {
+        title:
+          " 4송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
+        url: "https://m.entertain.naver.com/article/144/0000973128",
+      },
+      {
+        title: '" 5전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
+        url: "https://m.entertain.naver.com/article/144/0000973129",
+      },
+    ],
+  },
+  {
+    brandId: 2,
+    brandName: "헤럴드경제",
+    news: [
+      {
+        title:
+          "0 송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
+        url: "https://m.entertain.naver.com/article/144/0000973128",
+      },
+      {
+        title: '1 전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
+        url: "https://m.entertain.naver.com/article/144/0000973129",
+      },
+      {
+        title:
+          "2 송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
+        url: "https://m.entertain.naver.com/article/144/0000973128",
+      },
+      {
+        title: '" 3전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
+        url: "https://m.entertain.naver.com/article/144/0000973129",
+      },
+      {
+        title:
+          " 4송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
+        url: "https://m.entertain.naver.com/article/144/0000973128",
+      },
+      {
+        title: '" 5전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
+        url: "https://m.entertain.naver.com/article/144/0000973129",
+      },
+    ],
+  },
+];

--- a/data/currentNewsData.js
+++ b/data/currentNewsData.js
@@ -1,102 +1,58 @@
 export const currentNewsData = [
-  {
-    brandId: 0,
-    brandName: "서울경제",
-    news: [
-      {
-        title:
-          "0 송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
-        url: "https://m.entertain.naver.com/article/144/0000973128",
-      },
-      {
-        title: '1 전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
-        url: "https://m.entertain.naver.com/article/144/0000973129",
-      },
-      {
-        title:
-          "2 송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
-        url: "https://m.entertain.naver.com/article/144/0000973128",
-      },
-      {
-        title: '" 3전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
-        url: "https://m.entertain.naver.com/article/144/0000973129",
-      },
-      {
-        title:
-          " 4송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
-        url: "https://m.entertain.naver.com/article/144/0000973128",
-      },
-      {
-        title: '" 5전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
-        url: "https://m.entertain.naver.com/article/144/0000973129",
-      },
-    ],
-  },
-
-  {
-    brandId: 1,
-    brandName: "데일리안",
-    news: [
-      {
-        title:
-          "0 송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
-        url: "https://m.entertain.naver.com/article/144/0000973128",
-      },
-      {
-        title: '1 전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
-        url: "https://m.entertain.naver.com/article/144/0000973129",
-      },
-      {
-        title:
-          "2 송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
-        url: "https://m.entertain.naver.com/article/144/0000973128",
-      },
-      {
-        title: '" 3전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
-        url: "https://m.entertain.naver.com/article/144/0000973129",
-      },
-      {
-        title:
-          " 4송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
-        url: "https://m.entertain.naver.com/article/144/0000973128",
-      },
-      {
-        title: '" 5전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
-        url: "https://m.entertain.naver.com/article/144/0000973129",
-      },
-    ],
-  },
-  {
-    brandId: 2,
-    brandName: "헤럴드경제",
-    news: [
-      {
-        title:
-          "0 송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
-        url: "https://m.entertain.naver.com/article/144/0000973128",
-      },
-      {
-        title: '1 전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
-        url: "https://m.entertain.naver.com/article/144/0000973129",
-      },
-      {
-        title:
-          "2 송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
-        url: "https://m.entertain.naver.com/article/144/0000973128",
-      },
-      {
-        title: '" 3전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
-        url: "https://m.entertain.naver.com/article/144/0000973129",
-      },
-      {
-        title:
-          " 4송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
-        url: "https://m.entertain.naver.com/article/144/0000973128",
-      },
-      {
-        title: '" 5전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
-        url: "https://m.entertain.naver.com/article/144/0000973129",
-      },
-    ],
-  },
+  [
+    {
+      title:
+        "0 송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
+      url: "https://m.entertain.naver.com/article/144/0000973128",
+    },
+    {
+      title: '1 전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
+      url: "https://m.entertain.naver.com/article/144/0000973129",
+    },
+    {
+      title:
+        "2 송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
+      url: "https://m.entertain.naver.com/article/144/0000973128",
+    },
+    {
+      title: '" 3전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
+      url: "https://m.entertain.naver.com/article/144/0000973129",
+    },
+    {
+      title:
+        " 4송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼둥이 육아 전념 후회 無\" (유퀴즈)",
+      url: "https://m.entertain.naver.com/article/144/0000973128",
+    },
+    {
+      title: '" 5전화번호 좀" 에녹, 강혜연에 운명 직감? (신랑수업)',
+      url: "https://m.entertain.naver.com/article/144/0000973129",
+    },
+  ],
+  [
+    {
+      title: "0 송일국 \"'슈돌' 후 작품  전념 후회 無\" (유퀴즈)",
+      url: "https://m.entertain.naver.com/article/144/0000973128",
+    },
+    {
+      title: '1 전화번호 좀" 에녹, 강 직감? (신랑수업)',
+      url: "https://m.entertain.naver.com/article/144/0000973129",
+    },
+    {
+      title: '2 송일국 다 가족, 삼둥이 육아 전념 후회 無" (유퀴즈)',
+      url: "https://m.entertain.naver.com/article/144/0000973128",
+    },
+    {
+      title: '" 3전화번호 좀"  직감? (신랑수업)',
+      url: "https://m.entertain.naver.com/article/144/0000973129",
+    },
+    {
+      title:
+        " 4송일국 \"'슈돌' 후 작품 끊겨…일보다 가족, 삼념 후회 無\" (유퀴즈)",
+      url: "https://m.entertain.naver.com/article/144/0000973128",
+    },
+    {
+      title: '" 5전화번명 직감? (신랑수업)',
+      url: "https://m.entertain.naver.com/article/144/0000973129",
+    },
+  ],
 ];

--- a/index.html
+++ b/index.html
@@ -24,33 +24,20 @@
         <!-- 롤링바 -->
         <section class="flex-between gap-8">
           <div class="rolling-bar flex border-default surface-alt">
-            <div class="h-100">
-              <div
-                class="current-brand-1 text-strong display-bold14 mr-16"
-              ></div>
-              <div
-                class="current-brand-2 text-strong display-bold14 mr-16"
-              ></div>
-            </div>
+            <div class="flex-col p-16 text-strong display-bold14">
+              연합뉴스</div>
             <div class="h-100">
               <div class="current-news-1 text-default available-medium14"></div>
               <div class="current-news-2 text-default available-medium14"></div>
             </div>
           </div>
-          <div class="rolling-bar border-default surface-alt">
-            <div>
-              <div
-                class="current-brand-1 text-strong display-bold14 mr-16"
-              ></div>
-              <div
-                class="current-brand-2 text-strong display-bold14 mr-16"
-              ></div>
-            </div>
-            <div>
-              <div class="current-news-1 text-default available-medium14"></div>
-              <div class="current-news-2 text-default available-medium14"></div>
-            </div>
-          </div>
+          <div class="rolling-bar flex border-default surface-alt">
+              <div class="flex-col p-16 text-strong display-bold14">
+                연합뉴스</div>
+              <div class="h-100">
+                <div class="current-news-1 text-default available-medium14"></div>
+                <div class="current-news-2 text-default available-medium14"></div>
+              </div>
         </section>
 
         <div class="space-32"></div>

--- a/index.html
+++ b/index.html
@@ -21,21 +21,35 @@
       <div class="space-24"></div>
 
       <main>
-        <!-- 뉴스 바 -->
+        <!-- 롤링바 -->
         <section class="flex-between gap-8">
-          <div class="news-bar">
-            <div class="news-bar p-16 border-default surface-alt">
-              <span class="text-strong display-bold14 mr-16">연합뉴스</span>
-              <span class="text-default available-medium14">
-                [1보] 김기현·안철수·천하람·황교안, 與전대 본경선 진출
-              </span>
+          <div class="rolling-bar flex border-default surface-alt">
+            <div class="h-100">
+              <div
+                class="current-brand-1 text-strong display-bold14 mr-16"
+              ></div>
+              <div
+                class="current-brand-2 text-strong display-bold14 mr-16"
+              ></div>
+            </div>
+            <div class="h-100">
+              <div class="current-news-1 text-default available-medium14"></div>
+              <div class="current-news-2 text-default available-medium14"></div>
             </div>
           </div>
-          <div class="news-bar p-16 border-default surface-alt">
-            <span class="text-strong display-bold14 mr-16">연합뉴스</span>
-            <span class="text-default available-medium14">
-              [1보] 김기현·안철수·천하람·황교안, 與전대 본경선 진출
-            </span>
+          <div class="rolling-bar border-default surface-alt">
+            <div>
+              <div
+                class="current-brand-1 text-strong display-bold14 mr-16"
+              ></div>
+              <div
+                class="current-brand-2 text-strong display-bold14 mr-16"
+              ></div>
+            </div>
+            <div>
+              <div class="current-news-1 text-default available-medium14"></div>
+              <div class="current-news-2 text-default available-medium14"></div>
+            </div>
           </div>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -44,8 +44,7 @@
 
         <section>
           <!-- 구독, 그리드, 리스트 탭  -->
-          <div class="tab-and-viewer">
-            <div class="flex-between">
+          <div class="tab-and-viewer flex-between">
               <div class="flex-center gap-24">
                 <span class="press-tab-btn all-brand-tab-btn">전체 언론사</span>
                 <span class="press-tab-btn subscribe-brand-tab-btn"
@@ -62,9 +61,8 @@
                   src="asset\icons\grid-view.svg"
                 />
               </div>
-            </div>
           </div>
-
+          
           <div class="space-24"></div>
 
           <div class="news-list border-default">

--- a/index.js
+++ b/index.js
@@ -2,10 +2,10 @@ import { subscribeSwitchBtn } from "./components/subscriptionSwitchBtn/subscript
 import { header } from "./components/header/header.js";
 import { addSubscribe } from "./components/subscription/addsubscription.js";
 import { removeSubscribe } from "./components/subscription/removeSubscription.js";
-import { renderRollingBar } from "./components/rollingBar/rollingBar.js";
+import { initRollingBar } from "./components/rollingBar/rollingBar.js";
 
 header();
 subscribeSwitchBtn();
 addSubscribe();
 removeSubscribe();
-renderRollingBar();
+initRollingBar();

--- a/index.js
+++ b/index.js
@@ -2,8 +2,10 @@ import { subscribeSwitchBtn } from "./components/subscriptionSwitchBtn/subscript
 import { header } from "./components/header/header.js";
 import { addSubscribe } from "./components/subscription/addsubscription.js";
 import { removeSubscribe } from "./components/subscription/removeSubscription.js";
+import { renderRollingBar } from "./components/rollingBar/rollingBar.js";
 
 header();
 subscribeSwitchBtn();
 addSubscribe();
 removeSubscribe();
+renderRollingBar();

--- a/style.css
+++ b/style.css
@@ -5,14 +5,11 @@
 @import url("./components/fieldTab/style.css");
 @import url("./components/subscription/style.css");
 @import url("./components/toast/style.css");
+@import url("./components/rollingBar/style.css");
 
 .news-stand {
   width: 930px;
   margin-top: 100px;
-}
-
-.news-bar {
-  flex-grow: 1;
 }
 
 .tab-and-viewer {

--- a/style/common.css
+++ b/style/common.css
@@ -244,3 +244,7 @@
 .hidden {
   display: none;
 }
+
+.h-100 {
+  height: 100%;
+}

--- a/style/reset.css
+++ b/style/reset.css
@@ -10,6 +10,9 @@
 a {
   cursor: pointer;
   text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 button {


### PR DESCRIPTION
1. 가상선택자는 JS에서 조작하기 어려우므로, active fieldTab에 div를 하나 삽입해서 해당 요소를 조작하기로 변경
2. position : absolute로 버튼과 동일한 위치에 레이어를 한 겹 덧씌운다
3. setInterval로 width를 늘리며, 100%가 되었을 때 스와이프 함수를 호출한다.

- 다른 탭으로 이동했을 때 이전의 progress가 멈추지 않는 버그 발생
    
    이전에 생성된 intervalId가  clear 되지 않아서 생기는 문제이다.
    intervalId를 전역으로 두고 renderProgressBar 함수가 호출되자마자 이전의 intervalId를 clear해주는 방식으로 해결하였다.